### PR TITLE
Performance improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "earcut"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2021"
 description = "A Rust port of the Earcut polygon triangulation library"
 authors = ["Taku Fukada <naninunenor@gmail.com>", "MIERUNE Inc. <info@mierune.co.jp>"]
 license = "ISC"
 repository = "https://github.com/MIERUNE/earcut-rs"
-categories = ["graphics", "science"]
+categories = ["graphics", "science", "no-std"]
 
 [dependencies]
 num-traits = "0.2"

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -35,8 +35,8 @@ fn bench(c: &mut Criterion) {
     let mut earcut = Earcut::new();
     let mut triangles = Vec::new();
 
-    c.bench_function("water", |b| {
-        let (data, hole_indices) = load_fixture("water");
+    c.bench_function("bad-hole", |b| {
+        let (data, hole_indices) = load_fixture("bad-hole");
         b.iter(|| {
             earcut.earcut(data.iter().copied(), &hole_indices, &mut triangles);
         })
@@ -44,6 +44,34 @@ fn bench(c: &mut Criterion) {
 
     c.bench_function("building", |b| {
         let (data, hole_indices) = load_fixture("building");
+        b.iter(|| {
+            earcut.earcut(data.iter().copied(), &hole_indices, &mut triangles);
+        })
+    });
+
+    c.bench_function("degenerate", |b| {
+        let (data, hole_indices) = load_fixture("degenerate");
+        b.iter(|| {
+            earcut.earcut(data.iter().copied(), &hole_indices, &mut triangles);
+        })
+    });
+
+    c.bench_function("dude", |b| {
+        let (data, hole_indices) = load_fixture("dude");
+        b.iter(|| {
+            earcut.earcut(data.iter().copied(), &hole_indices, &mut triangles);
+        })
+    });
+
+    c.bench_function("empty-square", |b| {
+        let (data, hole_indices) = load_fixture("empty-square");
+        b.iter(|| {
+            earcut.earcut(data.iter().copied(), &hole_indices, &mut triangles);
+        })
+    });
+
+    c.bench_function("water", |b| {
+        let (data, hole_indices) = load_fixture("water");
         b.iter(|| {
             earcut.earcut(data.iter().copied(), &hole_indices, &mut triangles);
         })
@@ -70,6 +98,13 @@ fn bench(c: &mut Criterion) {
         })
     });
 
+    c.bench_function("water4", |b| {
+        let (data, hole_indices) = load_fixture("water4");
+        b.iter(|| {
+            earcut.earcut(data.iter().copied(), &hole_indices, &mut triangles);
+        })
+    });
+
     c.bench_function("water-huge", |b| {
         let (data, hole_indices) = load_fixture("water-huge");
         b.iter(|| {
@@ -85,19 +120,19 @@ fn bench(c: &mut Criterion) {
         })
     });
 
-    c.bench_function("rain", |b| {
-        let (data, hole_indices) = load_fixture("rain");
-        b.iter(|| {
-            earcut.earcut(data.iter().copied(), &hole_indices, &mut triangles);
-        })
-    });
+    // c.bench_function("rain", |b| {
+    //     let (data, hole_indices) = load_fixture("rain");
+    //     b.iter(|| {
+    //         earcut.earcut(data.iter().copied(), &hole_indices, &mut triangles);
+    //     })
+    // });
 
-    c.bench_function("hilbert", |b| {
-        let (data, hole_indices) = load_fixture("hilbert");
-        b.iter(|| {
-            earcut.earcut(data.iter().copied(), &hole_indices, &mut triangles);
-        })
-    });
+    // c.bench_function("hilbert", |b| {
+    //     let (data, hole_indices) = load_fixture("hilbert");
+    //     b.iter(|| {
+    //         earcut.earcut(data.iter().copied(), &hole_indices, &mut triangles);
+    //     })
+    // });
 }
 
 criterion_group!(benches, bench);

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -34,7 +34,7 @@ fn load_fixture(name: &str, num_triangles: usize, expected_deviation: f64) {
     }
 
     // check
-    assert!(triangles.len() == num_triangles);
+    assert!(triangles.len() == num_triangles * 3);
     if !triangles.is_empty() {
         assert!(
             deviation(vertices.iter().copied(), &hole_indices, &triangles) <= expected_deviation

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,8 @@ macro_rules! node_mut {
 struct Node<T: Float> {
     /// vertex index in coordinates array
     i: u32,
+    /// z-order curve value
+    z: i32,
     /// vertex coordinates x
     x: T,
     /// vertex coordinates y
@@ -69,8 +71,6 @@ struct Node<T: Float> {
     prev_i: u32,
     /// next vertex nodes in a polygon ring
     next_i: u32,
-    /// z-order curve value
-    z: i32,
     /// previous nodes in z-order
     prev_z_i: Option<u32>,
     /// next nodes in z-order
@@ -134,27 +134,26 @@ impl<T: Float> Earcut<T> {
         hole_indices: &[N],
         triangles_out: &mut Vec<N>,
     ) {
+        // initialize
         self.data.clear();
         self.data.extend(data);
-
         triangles_out.clear();
         self.reset(self.data.len() / 2 * 3 / 2);
-
         let has_holes = !hole_indices.is_empty();
         let outer_len: usize = if has_holes {
             hole_indices[0].into_usize() * 2
         } else {
             self.data.len()
         };
+
+        // create nodes
         let Some(mut outer_node_i) = self.linked_list(0, outer_len as u32, true) else {
             return;
         };
-
         let outer_node = node!(self.nodes, outer_node_i);
         if outer_node.next_i == outer_node.prev_i {
             return;
         }
-
         if has_holes {
             outer_node_i = self.eliminate_holes(hole_indices, outer_node_i);
         }
@@ -189,7 +188,15 @@ impl<T: Float> Earcut<T> {
             }
         }
 
-        self.earcut_linked(outer_node_i, triangles_out, min_x, min_y, inv_size, 0);
+        earcut_linked(
+            &mut self.nodes,
+            outer_node_i,
+            triangles_out,
+            min_x,
+            min_y,
+            inv_size,
+            Pass::P0,
+        );
     }
 
     /// create a circular doubly linked list from polygon points in the specified winding order
@@ -199,20 +206,16 @@ impl<T: Float> Earcut<T> {
             return None;
         }
 
+        let iter = self.data[start as usize..end as usize]
+            .chunks_exact(2)
+            .enumerate();
         if clockwise == (signed_area(&self.data, start, end) > T::zero()) {
-            for (i, v) in self.data[start as usize..end as usize]
-                .chunks_exact(2)
-                .enumerate()
-            {
+            for (i, v) in iter {
                 let idx = start + i as u32 * 2;
                 last_i = Some(insert_node(&mut self.nodes, idx, v[0], v[1], last_i));
             }
         } else {
-            for (i, v) in self.data[start as usize..end as usize]
-                .chunks_exact(2)
-                .enumerate()
-                .rev()
-            {
+            for (i, v) in iter.rev() {
                 let idx = start + i as u32 * 2;
                 last_i = Some(insert_node(&mut self.nodes, idx, v[0], v[1], last_i));
             }
@@ -229,313 +232,12 @@ impl<T: Float> Earcut<T> {
         last_i
     }
 
-    /// eliminate colinear or duplicate points
-    fn filter_points(&mut self, start_i: u32, end_i: Option<u32>) -> u32 {
-        let mut end_i = end_i.unwrap_or(start_i);
-
-        let mut p_i = start_i;
-        loop {
-            let p = node!(self.nodes, p_i);
-            let p_next = node!(self.nodes, p.next_i);
-            if !p.steiner
-                && (equals(p, p_next) || area(node!(self.nodes, p.prev_i), p, p_next).is_zero())
-            {
-                let (prev_i, next_i) = remove_node(&mut self.nodes, p_i);
-                (p_i, end_i) = (prev_i, prev_i);
-                if p_i == next_i {
-                    return end_i;
-                }
-            } else {
-                p_i = p.next_i;
-                if p_i == end_i {
-                    return end_i;
-                }
-            };
-        }
-    }
-
-    /// main ear slicing loop which triangulates a polygon (given as a linked list)
-    #[allow(clippy::too_many_arguments)]
-    fn earcut_linked<N: Index>(
-        &mut self,
-        ear_i: u32,
-        triangles: &mut Vec<N>,
-        min_x: T,
-        min_y: T,
-        inv_size: T,
-        pass: usize,
-    ) {
-        let mut ear_i = ear_i;
-
-        // interlink polygon nodes in z-order
-        if pass == 0 && inv_size != T::zero() {
-            self.index_curve(ear_i, min_x, min_y, inv_size);
-        }
-
-        let mut stop_i = ear_i;
-
-        // iterate through ears, slicing them one by one
-        while node!(self.nodes, ear_i).prev_i != node!(self.nodes, ear_i).next_i {
-            let ear = node!(self.nodes, ear_i);
-            let prev_i = ear.prev_i;
-            let next_i = ear.next_i;
-
-            let is_ear = if inv_size != T::zero() {
-                self.is_ear_hashed(ear_i, min_x, min_y, inv_size)
-            } else {
-                self.is_ear(ear_i)
-            };
-            if is_ear {
-                // cut off the triangle
-                triangles.extend([
-                    N::from_usize(node!(self.nodes, prev_i).i as usize / 2),
-                    N::from_usize(ear.i as usize / 2),
-                    N::from_usize(node!(self.nodes, next_i).i as usize / 2),
-                ]);
-
-                remove_node(&mut self.nodes, ear_i);
-
-                // skipping the next vertex leads to less sliver triangles
-                let next_next_i = node!(self.nodes, next_i).next_i;
-                (ear_i, stop_i) = (next_next_i, next_next_i);
-
-                continue;
-            }
-
-            ear_i = next_i;
-
-            // if we looped through the whole remaining polygon and can't find any more ears
-            if ear_i == stop_i {
-                if pass == 0 {
-                    // try filtering points and slicing again
-                    ear_i = self.filter_points(ear_i, None);
-                    self.earcut_linked(ear_i, triangles, min_x, min_y, inv_size, 1);
-                } else if pass == 1 {
-                    // if this didn't work, try curing all small self-intersections locally
-                    let filtered = self.filter_points(ear_i, None);
-                    ear_i = self.cure_local_intersections(filtered, triangles);
-                    self.earcut_linked(ear_i, triangles, min_x, min_y, inv_size, 2);
-                } else if pass == 2 {
-                    // as a last resort, try splitting the remaining polygon into two
-                    self.split_earcut(ear_i, triangles, min_x, min_y, inv_size);
-                }
-                return;
-            }
-        }
-    }
-
-    /// check whether a polygon node forms a valid ear with adjacent nodes
-    fn is_ear(&self, ear_i: u32) -> bool {
-        let b = node!(self.nodes, ear_i);
-        let a = node!(self.nodes, b.prev_i);
-        let c = node!(self.nodes, b.next_i);
-
-        if area(a, b, c) >= T::zero() {
-            // reflex, can't be an ear
-            return false;
-        }
-
-        // now make sure we don't have other points inside the potential ear
-
-        // triangle bbox
-        let x0 = a.x.min(b.x.min(c.x));
-        let y0 = a.y.min(b.y.min(c.y));
-        let x1 = a.x.max(b.x.max(c.x));
-        let y1 = a.y.max(b.y.max(c.y));
-
-        let mut p = node!(self.nodes, c.next_i);
-        let mut p_prev = node!(self.nodes, p.prev_i);
-        while !ptr::eq(p, a) {
-            let p_next = node!(self.nodes, p.next_i);
-            if (p.x >= x0 && p.x <= x1 && p.y >= y0 && p.y <= y1)
-                && point_in_triangle(a.x, a.y, b.x, b.y, c.x, c.y, p.x, p.y)
-                && area(p_prev, p, p_next) >= T::zero()
-            {
-                return false;
-            }
-            (p_prev, p) = (p, p_next);
-        }
-        true
-    }
-
-    fn is_ear_hashed(&self, ear_i: u32, min_x: T, min_y: T, inv_size: T) -> bool {
-        let b = node!(self.nodes, ear_i);
-        let a = node!(self.nodes, b.prev_i);
-        let c = node!(self.nodes, b.next_i);
-
-        if area(a, b, c) >= T::zero() {
-            // reflex, can't be an ear
-            return false;
-        }
-
-        // triangle bbox
-        let x0 = a.x.min(b.x.min(c.x));
-        let y0 = a.y.min(b.y.min(c.y));
-        let x1 = a.x.max(b.x.max(c.x));
-        let y1 = a.y.max(b.y.max(c.y));
-
-        // z-order range for the current triangle bbox;
-        let min_z = z_order(x0, y0, min_x, min_y, inv_size);
-        let max_z = z_order(x1, y1, min_x, min_y, inv_size);
-
-        let ear = node!(self.nodes, ear_i);
-        let mut o_p = ear.prev_z_i.map(|i| node!(self.nodes, i as usize));
-        let mut o_n = ear.next_z_i.map(|i| node!(self.nodes, i));
-
-        let ear_prev = node!(self.nodes, ear.prev_i);
-        let ear_next = node!(self.nodes, ear.next_i);
-
-        // look for points inside the triangle in both directions
-        loop {
-            let Some(p) = o_p else { break };
-            if p.z < min_z {
-                break;
-            };
-            let Some(n) = o_n else { break };
-            if n.z > max_z {
-                break;
-            };
-
-            if (p.x >= x0 && p.x <= x1 && p.y >= y0 && p.y <= y1)
-                && (!ptr::eq(p, a) && !ptr::eq(p, c))
-                && point_in_triangle(a.x, a.y, b.x, b.y, c.x, c.y, p.x, p.y)
-                && area(node!(self.nodes, p.prev_i), p, node!(self.nodes, p.next_i)) >= T::zero()
-            {
-                return false;
-            }
-            o_p = p.prev_z_i.map(|i| node!(self.nodes, i));
-
-            if (n.x >= x0 && n.x <= x1 && n.y >= y0 && n.y <= y1)
-                && (!ptr::eq(n, a) && !ptr::eq(n, c))
-                && point_in_triangle(a.x, a.y, b.x, b.y, c.x, c.y, n.x, n.y)
-                && area(node!(self.nodes, n.prev_i), n, node!(self.nodes, n.next_i)) >= T::zero()
-            {
-                return false;
-            }
-            o_n = p.next_z_i.map(|i| node!(self.nodes, i));
-        }
-
-        // look for remaining points in decreasing z-order
-        while let Some(p) = o_p {
-            if p.z < min_z {
-                break;
-            };
-            if (!ptr::eq(p, ear_prev) && !ptr::eq(p, ear_next))
-                && point_in_triangle(a.x, a.y, b.x, b.y, c.x, c.y, p.x, p.y)
-                && area(node!(self.nodes, p.prev_i), p, node!(self.nodes, p.next_i)) >= T::zero()
-            {
-                return false;
-            }
-            o_p = p.prev_z_i.map(|i| node!(self.nodes, i));
-        }
-
-        // look for remaining points in increasing z-order
-        while let Some(n) = o_n {
-            if n.z > max_z {
-                break;
-            };
-            if (!ptr::eq(n, ear_prev) && !ptr::eq(n, ear_next))
-                && point_in_triangle(a.x, a.y, b.x, b.y, c.x, c.y, n.x, n.y)
-                && area(node!(self.nodes, n.prev_i), n, node!(self.nodes, n.next_i)) >= T::zero()
-            {
-                return false;
-            }
-            o_n = n.next_z_i.map(|i| node!(self.nodes, i));
-        }
-
-        true
-    }
-
-    /// go through all polygon nodes and cure small local self-intersections
-    fn cure_local_intersections<N: Index>(
-        &mut self,
-        mut start_i: u32,
-        triangles: &mut Vec<N>,
-    ) -> u32 {
-        let mut p_i = start_i;
-        loop {
-            let p_prev_i = node!(self.nodes, p_i).prev_i;
-            let p_next_i = node!(self.nodes, p_i).next_i;
-            let a_i = p_prev_i;
-            let p_next = node!(self.nodes, p_next_i);
-            let b_i = p_next.next_i;
-            let a = node!(self.nodes, a_i);
-            let b = node!(self.nodes, b_i);
-            let p = node!(self.nodes, p_i);
-
-            if !equals(a, b)
-                && self.intersects(a, p, p_next, b)
-                && self.locally_inside(a, b)
-                && self.locally_inside(b, a)
-            {
-                triangles.extend([
-                    N::from_usize(a.i as usize / 2),
-                    N::from_usize(p.i as usize / 2),
-                    N::from_usize(b.i as usize / 2),
-                ]);
-
-                remove_node(&mut self.nodes, p_i);
-                remove_node(&mut self.nodes, p_next_i);
-
-                (p_i, start_i) = (b_i, b_i);
-            }
-
-            p_i = node!(self.nodes, p_i).next_i;
-            if p_i == start_i {
-                return self.filter_points(p_i, None);
-            }
-        }
-    }
-
-    /// try splitting polygon into two and triangulate them independently
-    fn split_earcut<N: Index>(
-        &mut self,
-        start_i: u32,
-        triangles: &mut Vec<N>,
-        min_x: T,
-        min_y: T,
-        inv_size: T,
-    ) {
-        // look for a valid diagonal that divides the polygon into two
-        let mut a_i = start_i;
-        loop {
-            let ai = node!(self.nodes, a_i).i;
-            let a_prev_i = node!(self.nodes, a_i).prev_i;
-            let a_next_i = node!(self.nodes, a_i).next_i;
-            let mut b_i = (node!(self.nodes, a_next_i)).next_i;
-
-            while b_i != a_prev_i {
-                let b = node!(self.nodes, b_i);
-                if ai != b.i && self.is_valid_diagonal(node!(self.nodes, a_i), b) {
-                    // split the polygon in two by the diagonal
-                    let mut c_i = self.split_polygon(a_i, b_i);
-
-                    // filter colinear points around the cuts
-                    a_i = self.filter_points(a_i, Some(node!(self.nodes, a_i).next_i));
-                    c_i = self.filter_points(c_i, Some(node!(self.nodes, c_i).next_i));
-
-                    // run earcut on each half
-                    self.earcut_linked(a_i, triangles, min_x, min_y, inv_size, 0);
-                    self.earcut_linked(c_i, triangles, min_x, min_y, inv_size, 0);
-                    return;
-                }
-                b_i = b.next_i;
-            }
-
-            a_i = node!(self.nodes, a_i).next_i;
-            if a_i == start_i {
-                return;
-            }
-        }
-    }
-
     /// link every hole into the outer loop, producing a single-ring polygon without holes
     fn eliminate_holes<N: Index>(&mut self, hole_indices: &[N], mut outer_node_i: u32) -> u32 {
         self.queue.clear();
-        let len = hole_indices.len();
         for (i, hi) in hole_indices.iter().enumerate() {
             let start = (*hi).into_usize() * 2;
-            let end = if i < len - 1 {
+            let end = if i < hole_indices.len() - 1 {
                 hole_indices[i + 1].into_usize() * 2
             } else {
                 self.data.len()
@@ -545,7 +247,7 @@ impl<T: Float> Earcut<T> {
                 if list_i == list.next_i {
                     list.steiner = true;
                 }
-                self.queue.push(self.get_leftmost(list_i))
+                self.queue.push(get_leftmost(&self.nodes, list_i))
             }
         }
 
@@ -557,342 +259,643 @@ impl<T: Float> Earcut<T> {
         });
 
         // process holes from left to right
-        for i in 0..self.queue.len() {
-            outer_node_i = self.eliminate_hole(self.queue[i], outer_node_i);
+        for &q in &self.queue {
+            outer_node_i = eliminate_hole(&mut self.nodes, q, outer_node_i);
         }
 
         outer_node_i
     }
+}
 
-    /// find a bridge between vertices that connects hole with an outer ring and and link it
-    fn eliminate_hole(&mut self, hole_i: u32, outer_node_i: u32) -> u32 {
-        let Some(bridge_i) = self.find_hole_bridge(node!(self.nodes, hole_i), outer_node_i) else {
-            return outer_node_i;
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Pass {
+    P0 = 0,
+    P1 = 1,
+    P2 = 2,
+}
+
+/// main ear slicing loop which triangulates a polygon (given as a linked list)
+#[allow(clippy::too_many_arguments)]
+fn earcut_linked<T: Float, N: Index>(
+    nodes: &mut Vec<Node<T>>,
+    ear_i: u32,
+    triangles: &mut Vec<N>,
+    min_x: T,
+    min_y: T,
+    inv_size: T,
+    pass: Pass,
+) {
+    let mut ear_i = ear_i;
+
+    // interlink polygon nodes in z-order
+    if pass == Pass::P0 && inv_size != T::zero() {
+        index_curve(nodes, ear_i, min_x, min_y, inv_size);
+    }
+
+    let mut stop_i = ear_i;
+
+    // iterate through ears, slicing them one by one
+    while node!(nodes, ear_i).prev_i != node!(nodes, ear_i).next_i {
+        let ear = node!(nodes, ear_i);
+        let prev_i = ear.prev_i;
+        let next_i = ear.next_i;
+
+        let is_ear = if inv_size != T::zero() {
+            is_ear_hashed(nodes, ear_i, min_x, min_y, inv_size)
+        } else {
+            is_ear(nodes, ear_i)
         };
-        let bridge_reverse_i = self.split_polygon(bridge_i, hole_i);
+        if is_ear {
+            // cut off the triangle
+            triangles.extend([
+                N::from_usize(node!(nodes, prev_i).i as usize / 2),
+                N::from_usize(ear.i as usize / 2),
+                N::from_usize(node!(nodes, next_i).i as usize / 2),
+            ]);
 
-        // filter collinear points around the cuts
-        self.filter_points(
-            bridge_reverse_i,
-            Some(node!(self.nodes, bridge_reverse_i).next_i),
-        );
-        self.filter_points(bridge_i, Some(node!(self.nodes, bridge_i).next_i))
-    }
+            remove_node(nodes, ear_i);
 
-    /// dimavid Eberly's algorithm for finding a bridge between hole and outer polygon
-    fn find_hole_bridge(&self, hole: &Node<T>, outer_node_i: u32) -> Option<u32> {
-        let mut p_i = outer_node_i;
-        let mut qx = T::neg_infinity();
-        let mut m_i: Option<u32> = None;
+            // skipping the next vertex leads to less sliver triangles
+            let next_next_i = node!(nodes, next_i).next_i;
+            (ear_i, stop_i) = (next_next_i, next_next_i);
 
-        // find a segment intersected by a ray from the hole's leftmost point to the left;
-        // segment's endpoint with lesser x will be potential connection point
-        loop {
-            let p = node!(self.nodes, p_i);
-            let p_next_i = p.next_i;
-            let p_next = node!(self.nodes, p_next_i);
-            if hole.y <= p.y && hole.y >= p_next.y && p_next.y != p.y {
-                let x = p.x + (hole.y - p.y) * (p_next.x - p.x) / (p_next.y - p.y);
-                if x <= hole.x && x > qx {
-                    qx = x;
-                    m_i = Some(if p.x < p_next.x { p_i } else { p_next_i });
-                    if x == hole.x {
-                        // hole touches outer segment; pick leftmost endpoint
-                        return m_i;
-                    }
-                }
-            }
-            p_i = p_next_i;
-            if p_i == outer_node_i {
-                break;
-            }
+            continue;
         }
 
-        let mut m_i = m_i?;
+        ear_i = next_i;
 
-        // look for points inside the triangle of hole point, segment intersection and endpoint;
-        // if there are no points found, we have a valid connection;
-        // otherwise choose the point of the minimum angle with the ray as connection point
-
-        let stop_i = m_i;
-        let Node { x: mx, y: my, .. } = *node!(self.nodes, m_i); // must copy
-        let mut tan_min = T::infinity();
-
-        p_i = m_i;
-        let mut p = node!(self.nodes, p_i);
-        let mut m = p;
-
-        loop {
-            if (hole.x >= p.x && p.x >= mx && hole.x != p.x)
-                && point_in_triangle(
-                    if hole.y < my { hole.x } else { qx },
-                    hole.y,
-                    mx,
-                    my,
-                    if hole.y < my { qx } else { hole.x },
-                    hole.y,
-                    p.x,
-                    p.y,
-                )
-            {
-                let tan = (hole.y - p.y).abs() / (hole.x - p.x);
-                if self.locally_inside(p, hole)
-                    && (tan < tan_min
-                        || (tan == tan_min
-                            && (p.x > m.x || p.x == m.x && self.sector_contains_sector(m, p))))
-                {
-                    (m_i, m) = (p_i, p);
-                    tan_min = tan;
-                }
+        // if we looped through the whole remaining polygon and can't find any more ears
+        if ear_i == stop_i {
+            if pass == Pass::P0 {
+                // try filtering points and slicing again
+                ear_i = filter_points(nodes, ear_i, None);
+                earcut_linked(nodes, ear_i, triangles, min_x, min_y, inv_size, Pass::P1);
+            } else if pass == Pass::P1 {
+                // if this didn't work, try curing all small self-intersections locally
+                let filtered = filter_points(nodes, ear_i, None);
+                ear_i = cure_local_intersections(nodes, filtered, triangles);
+                earcut_linked(nodes, ear_i, triangles, min_x, min_y, inv_size, Pass::P2);
+            } else if pass == Pass::P2 {
+                // as a last resort, try splitting the remaining polygon into two
+                split_earcut(nodes, ear_i, triangles, min_x, min_y, inv_size);
             }
+            return;
+        }
+    }
+}
 
-            p_i = p.next_i;
-            if p_i == stop_i {
-                return Some(m_i);
+/// check whether a polygon node forms a valid ear with adjacent nodes
+fn is_ear<T: Float>(nodes: &[Node<T>], ear_i: u32) -> bool {
+    let b = node!(nodes, ear_i);
+    let a = node!(nodes, b.prev_i);
+    let c = node!(nodes, b.next_i);
+
+    if area(a, b, c) >= T::zero() {
+        // reflex, can't be an ear
+        return false;
+    }
+
+    // now make sure we don't have other points inside the potential ear
+
+    // triangle bbox
+    let x0 = a.x.min(b.x.min(c.x));
+    let y0 = a.y.min(b.y.min(c.y));
+    let x1 = a.x.max(b.x.max(c.x));
+    let y1 = a.y.max(b.y.max(c.y));
+
+    let mut p = node!(nodes, c.next_i);
+    let mut p_prev = node!(nodes, p.prev_i);
+    while !ptr::eq(p, a) {
+        let p_next = node!(nodes, p.next_i);
+        if (p.x >= x0 && p.x <= x1 && p.y >= y0 && p.y <= y1)
+            && point_in_triangle(a.x, a.y, b.x, b.y, c.x, c.y, p.x, p.y)
+            && area(p_prev, p, p_next) >= T::zero()
+        {
+            return false;
+        }
+        (p_prev, p) = (p, p_next);
+    }
+    true
+}
+
+fn is_ear_hashed<T: Float>(nodes: &[Node<T>], ear_i: u32, min_x: T, min_y: T, inv_size: T) -> bool {
+    let b = node!(nodes, ear_i);
+    let a = node!(nodes, b.prev_i);
+    let c = node!(nodes, b.next_i);
+
+    if area(a, b, c) >= T::zero() {
+        // reflex, can't be an ear
+        return false;
+    }
+
+    // triangle bbox
+    let x0 = a.x.min(b.x.min(c.x));
+    let y0 = a.y.min(b.y.min(c.y));
+    let x1 = a.x.max(b.x.max(c.x));
+    let y1 = a.y.max(b.y.max(c.y));
+
+    // z-order range for the current triangle bbox;
+    let min_z = z_order(x0, y0, min_x, min_y, inv_size);
+    let max_z = z_order(x1, y1, min_x, min_y, inv_size);
+
+    let ear = node!(nodes, ear_i);
+    let mut o_p = ear.prev_z_i.map(|i| node!(nodes, i as usize));
+    let mut o_n = ear.next_z_i.map(|i| node!(nodes, i));
+
+    // NOTE: Disabled this part because it rather degrades performance.
+    //
+    // look for points inside the triangle in both directions
+    loop {
+        let Some(p) = o_p else { break };
+        if p.z < min_z {
+            break;
+        };
+        let Some(n) = o_n else { break };
+        if n.z > max_z {
+            break;
+        };
+
+        if (p.x >= x0 && p.x <= x1 && p.y >= y0 && p.y <= y1)
+            && (!ptr::eq(p, a) && !ptr::eq(p, c))
+            && point_in_triangle(a.x, a.y, b.x, b.y, c.x, c.y, p.x, p.y)
+            && area(node!(nodes, p.prev_i), p, node!(nodes, p.next_i)) >= T::zero()
+        {
+            return false;
+        }
+        o_p = p.prev_z_i.map(|i| node!(nodes, i));
+
+        if (n.x >= x0 && n.x <= x1 && n.y >= y0 && n.y <= y1)
+            && (!ptr::eq(n, a) && !ptr::eq(n, c))
+            && point_in_triangle(a.x, a.y, b.x, b.y, c.x, c.y, n.x, n.y)
+            && area(node!(nodes, n.prev_i), n, node!(nodes, n.next_i)) >= T::zero()
+        {
+            return false;
+        }
+        o_n = n.next_z_i.map(|i| node!(nodes, i));
+    }
+
+    // look for remaining points in decreasing z-order
+    while let Some(p) = o_p {
+        if p.z < min_z {
+            break;
+        };
+        if (p.x >= x0 && p.x <= x1 && p.y >= y0 && p.y <= y1)
+            && (!ptr::eq(p, a) && !ptr::eq(p, c))
+            && point_in_triangle(a.x, a.y, b.x, b.y, c.x, c.y, p.x, p.y)
+            && area(node!(nodes, p.prev_i), p, node!(nodes, p.next_i)) >= T::zero()
+        {
+            return false;
+        }
+        o_p = p.prev_z_i.map(|i| node!(nodes, i));
+    }
+
+    // look for remaining points in increasing z-order
+    while let Some(n) = o_n {
+        if n.z > max_z {
+            break;
+        };
+        if (n.x >= x0 && n.x <= x1 && n.y >= y0 && n.y <= y1)
+            && (!ptr::eq(n, a) && !ptr::eq(n, c))
+            && point_in_triangle(a.x, a.y, b.x, b.y, c.x, c.y, n.x, n.y)
+            && area(node!(nodes, n.prev_i), n, node!(nodes, n.next_i)) >= T::zero()
+        {
+            return false;
+        }
+        o_n = n.next_z_i.map(|i| node!(nodes, i));
+    }
+
+    true
+}
+
+/// go through all polygon nodes and cure small local self-intersections
+fn cure_local_intersections<T: Float, N: Index>(
+    nodes: &mut [Node<T>],
+    mut start_i: u32,
+    triangles: &mut Vec<N>,
+) -> u32 {
+    let mut p_i = start_i;
+    loop {
+        let p = node!(nodes, p_i);
+        let p_next_i = p.next_i;
+        let p_next = node!(nodes, p_next_i);
+        let b_i = p_next.next_i;
+        let a = node!(nodes, p.prev_i);
+        let b = node!(nodes, b_i);
+
+        if !equals(a, b)
+            && intersects(a, p, p_next, b)
+            && locally_inside(nodes, a, b)
+            && locally_inside(nodes, b, a)
+        {
+            triangles.extend([
+                N::from_usize(a.i as usize / 2),
+                N::from_usize(p.i as usize / 2),
+                N::from_usize(b.i as usize / 2),
+            ]);
+
+            remove_node(nodes, p_i);
+            remove_node(nodes, p_next_i);
+
+            (p_i, start_i) = (b_i, b_i);
+        }
+
+        p_i = node!(nodes, p_i).next_i;
+        if p_i == start_i {
+            return filter_points(nodes, p_i, None);
+        }
+    }
+}
+
+/// try splitting polygon into two and triangulate them independently
+fn split_earcut<T: Float, N: Index>(
+    nodes: &mut Vec<Node<T>>,
+    start_i: u32,
+    triangles: &mut Vec<N>,
+    min_x: T,
+    min_y: T,
+    inv_size: T,
+) {
+    // look for a valid diagonal that divides the polygon into two
+    let mut ai = start_i;
+    loop {
+        let a = node!(nodes, ai);
+        let a_i = a.i;
+        let a_prev_i = a.prev_i;
+        let a_next_i = a.next_i;
+        let mut bi = (node!(nodes, a_next_i)).next_i;
+
+        while bi != a_prev_i {
+            let b = node!(nodes, bi);
+            if a_i != b.i && is_valid_diagonal(nodes, a, b) {
+                // split the polygon in two by the diagonal
+                let mut ci = split_polygon(nodes, ai, bi);
+
+                // filter colinear points around the cuts
+                let end_i = Some(node!(nodes, ai).next_i);
+                ai = filter_points(nodes, ai, end_i);
+                let end_i = Some(node!(nodes, ci).next_i);
+                ci = filter_points(nodes, ci, end_i);
+
+                // run earcut on each half
+                earcut_linked(nodes, ai, triangles, min_x, min_y, inv_size, Pass::P0);
+                earcut_linked(nodes, ci, triangles, min_x, min_y, inv_size, Pass::P0);
+                return;
             }
-            p = node!(self.nodes, p_i);
+            bi = b.next_i;
+        }
+
+        ai = node!(nodes, ai).next_i;
+        if ai == start_i {
+            return;
+        }
+    }
+}
+
+/// interlink polygon nodes in z-order
+fn index_curve<T: Float>(nodes: &mut [Node<T>], start_i: u32, min_x: T, min_y: T, inv_size: T) {
+    let mut p_i = start_i;
+
+    loop {
+        let p = node_mut!(nodes, p_i);
+        if p.z == 0 {
+            p.z = z_order(p.x, p.y, min_x, min_y, inv_size);
+        }
+        p.prev_z_i = Some(p.prev_i);
+        p.next_z_i = Some(p.next_i);
+        p_i = p.next_i;
+        if p_i == start_i {
+            break;
         }
     }
 
-    /// whether sector in vertex m contains sector in vertex p in the same coordinates
-    fn sector_contains_sector(&self, m: &Node<T>, p: &Node<T>) -> bool {
-        area(node!(self.nodes, m.prev_i), m, node!(self.nodes, p.prev_i)) < T::zero()
-            && area(node!(self.nodes, p.next_i), m, node!(self.nodes, m.next_i)) < T::zero()
-    }
+    let p_prev_z_i = node!(nodes, p_i).prev_z_i.unwrap();
+    node_mut!(nodes, p_prev_z_i).next_z_i = None;
+    node_mut!(nodes, p_i).prev_z_i = None;
+    sort_linked(nodes, p_i);
+}
 
-    /// interlink polygon nodes in z-order
-    fn index_curve(&mut self, start_i: u32, min_x: T, min_y: T, inv_size: T) {
-        let mut p_i = start_i;
+/// Simon Tatham's linked list merge sort algorithm
+/// http://www.chiark.greenend.org.uk/~sgtatham/algorithms/listsort.html
+fn sort_linked<T: Float>(nodes: &mut [Node<T>], list_i: u32) {
+    let mut in_size: usize = 1;
+    let mut list_i = Some(list_i);
 
-        loop {
-            let p = node_mut!(self.nodes, p_i);
-            if p.z == 0 {
-                p.z = z_order(p.x, p.y, min_x, min_y, inv_size);
-            }
-            p.prev_z_i = Some(p.prev_i);
-            p.next_z_i = Some(p.next_i);
-            p_i = p.next_i;
-            if p_i == start_i {
-                break;
-            }
-        }
+    loop {
+        let mut p_i = list_i;
+        list_i = None;
+        let mut tail_i: Option<u32> = None;
+        let mut num_merges = 0;
 
-        let p_prev_z_i = node!(self.nodes, p_i).prev_z_i.unwrap();
-        node_mut!(self.nodes, p_prev_z_i).next_z_i = None;
-        node_mut!(self.nodes, p_i).prev_z_i = None;
-        self.sort_linked(p_i);
-    }
-
-    /// Simon Tatham's linked list merge sort algorithm
-    /// http://www.chiark.greenend.org.uk/~sgtatham/algorithms/listsort.html
-    fn sort_linked(&mut self, list_i: u32) {
-        let mut in_size: usize = 1;
-        let mut list_i = Some(list_i);
-
-        loop {
-            let mut p_i = list_i;
-            list_i = None;
-            let mut tail_i: Option<u32> = None;
-            let mut num_merges = 0;
-
-            while let Some(pp) = p_i {
-                num_merges += 1;
-                let mut q_i = node!(self.nodes, pp).next_z_i;
-                let mut p_size: u32 = 1;
-                for _ in 1..in_size {
-                    if let Some(i) = q_i {
-                        p_size += 1;
-                        q_i = node!(self.nodes, i).next_z_i;
-                    } else {
-                        q_i = None;
-                        break;
-                    }
+        while let Some(pp) = p_i {
+            num_merges += 1;
+            let mut q_i = node!(nodes, pp).next_z_i;
+            let mut p_size: u32 = 1;
+            for _ in 1..in_size {
+                if let Some(i) = q_i {
+                    p_size += 1;
+                    q_i = node!(nodes, i).next_z_i;
+                } else {
+                    q_i = None;
+                    break;
                 }
-                let mut q_size = in_size;
+            }
+            let mut q_size = in_size;
 
-                while p_size > 0 || (q_size > 0 && q_i.is_some()) {
-                    let (e_i, e) = if p_size == 0 {
-                        q_size -= 1;
-                        let e_i = q_i.unwrap();
-                        let e = node_mut!(self.nodes, e_i);
-                        q_i = e.next_z_i;
-                        (e_i, e)
-                    } else if q_size == 0 {
-                        p_size -= 1;
-                        let e_i = p_i.unwrap();
-                        let e = node_mut!(self.nodes, e_i);
-                        p_i = e.next_z_i;
-                        (e_i, e)
-                    } else {
-                        let p_i_s = p_i.unwrap();
-                        if let Some(q_i_s) = q_i {
-                            if node!(self.nodes, p_i_s).z <= node!(self.nodes, q_i_s).z {
-                                p_size -= 1;
-                                let e_i = p_i_s;
-                                let e = node_mut!(self.nodes, p_i_s);
-                                p_i = e.next_z_i;
-                                (e_i, e)
-                            } else {
-                                q_size -= 1;
-                                let e_i = q_i_s;
-                                let e = node_mut!(self.nodes, q_i_s);
-                                q_i = e.next_z_i;
-                                (e_i, e)
-                            }
-                        } else {
+            while p_size > 0 || (q_size > 0 && q_i.is_some()) {
+                let (e_i, e) = if p_size == 0 {
+                    q_size -= 1;
+                    let e_i = q_i.unwrap();
+                    let e = node_mut!(nodes, e_i);
+                    q_i = e.next_z_i;
+                    (e_i, e)
+                } else if q_size == 0 {
+                    p_size -= 1;
+                    let e_i = p_i.unwrap();
+                    let e = node_mut!(nodes, e_i);
+                    p_i = e.next_z_i;
+                    (e_i, e)
+                } else {
+                    let p_i_s = p_i.unwrap();
+                    if let Some(q_i_s) = q_i {
+                        if node!(nodes, p_i_s).z <= node!(nodes, q_i_s).z {
                             p_size -= 1;
-                            let e_i = p_i_s;
-                            let e = node_mut!(self.nodes, e_i);
+                            let e = node_mut!(nodes, p_i_s);
                             p_i = e.next_z_i;
-                            (e_i, e)
+                            (p_i_s, e)
+                        } else {
+                            q_size -= 1;
+                            let e = node_mut!(nodes, q_i_s);
+                            q_i = e.next_z_i;
+                            (q_i_s, e)
                         }
-                    };
-
-                    e.prev_z_i = tail_i;
-
-                    if let Some(tail_i) = tail_i {
-                        node_mut!(self.nodes, tail_i).next_z_i = Some(e_i);
                     } else {
-                        list_i = Some(e_i);
+                        p_size -= 1;
+                        let e = node_mut!(nodes, p_i_s);
+                        p_i = e.next_z_i;
+                        (p_i_s, e)
                     }
-                    tail_i = Some(e_i);
+                };
+
+                e.prev_z_i = tail_i;
+
+                if let Some(tail_i) = tail_i {
+                    node_mut!(nodes, tail_i).next_z_i = Some(e_i);
+                } else {
+                    list_i = Some(e_i);
                 }
-
-                p_i = q_i;
+                tail_i = Some(e_i);
             }
 
-            node_mut!(self.nodes, tail_i.unwrap()).next_z_i = None;
-            if num_merges <= 1 {
-                break;
-            }
-            in_size *= 2;
+            p_i = q_i;
         }
-    }
 
-    /// find the leftmost node of a polygon ring
-    fn get_leftmost(&self, start_i: u32) -> u32 {
-        let mut p_i = start_i;
-        let mut leftmost_i = start_i;
-        let mut p = node!(self.nodes, p_i);
-        let mut leftmost = p;
-
-        loop {
-            if p.x < leftmost.x || (p.x == leftmost.x && p.y < leftmost.y) {
-                (leftmost_i, leftmost) = (p_i, p);
-            }
-            p_i = p.next_i;
-            if p_i == start_i {
-                return leftmost_i;
-            }
-            p = node!(self.nodes, p_i);
+        node_mut!(nodes, tail_i.unwrap()).next_z_i = None;
+        if num_merges <= 1 {
+            break;
         }
+        in_size *= 2;
     }
+}
 
-    /// check if a diagonal between two polygon nodes is valid (lies in polygon interior)
-    fn is_valid_diagonal(&self, a: &Node<T>, b: &Node<T>) -> bool {
-        let a_next = node!(self.nodes, a.next_i);
-        let a_prev = node!(self.nodes, a.prev_i);
-        let b_next = node!(self.nodes, b.next_i);
-        let b_prev = node!(self.nodes, b.prev_i);
-        // dones't intersect other edges
-        (a_next.i != b.i && a_prev.i != b.i && !self.intersects_polygon(a, b))
+/// find the leftmost node of a polygon ring
+fn get_leftmost<T: Float>(nodes: &[Node<T>], start_i: u32) -> u32 {
+    let mut p_i = start_i;
+    let mut leftmost_i = start_i;
+    let mut p = node!(nodes, p_i);
+    let mut leftmost = p;
+
+    loop {
+        if p.x < leftmost.x || (p.x == leftmost.x && p.y < leftmost.y) {
+            (leftmost_i, leftmost) = (p_i, p);
+        }
+        p_i = p.next_i;
+        if p_i == start_i {
+            return leftmost_i;
+        }
+        p = node!(nodes, p_i);
+    }
+}
+
+/// check if a diagonal between two polygon nodes is valid (lies in polygon interior)
+fn is_valid_diagonal<T: Float>(nodes: &[Node<T>], a: &Node<T>, b: &Node<T>) -> bool {
+    let a_next = node!(nodes, a.next_i);
+    let a_prev = node!(nodes, a.prev_i);
+    let b_next = node!(nodes, b.next_i);
+    let b_prev = node!(nodes, b.prev_i);
+    // dones't intersect other edges
+    (a_next.i != b.i && a_prev.i != b.i && !intersects_polygon(nodes, a, b))
             // locally visible
-            && ((self.locally_inside(a, b) && self.locally_inside(b, a) && self.middle_inside(a, b))
+            && ((locally_inside(nodes, a, b) && locally_inside(nodes, b, a) && middle_inside(nodes, a, b))
                 // does not create opposite-facing sectors
                 && (area(a_prev, a, b_prev) != T::zero() || area(a, b_prev, b) != T::zero())
                 // special zero-length case
                 || equals(a, b)
                     && area(a_prev, a, a_next) > T::zero()
                     && area(b_prev, b, b_next) > T::zero())
+}
+
+/// check if two segments intersect
+fn intersects<T: Float>(p1: &Node<T>, q1: &Node<T>, p2: &Node<T>, q2: &Node<T>) -> bool {
+    let o1 = sign(area(p1, q1, p2));
+    let o2 = sign(area(p1, q1, q2));
+    let o3 = sign(area(p2, q2, p1));
+    let o4 = sign(area(p2, q2, q1));
+    (o1 != o2 && o3 != o4) // general case
+        || (o1 == 0 && on_segment(p1, p2, q1)) // p1, q1 and p2 are collinear and p2 lies on p1q1
+        || (o2 == 0 && on_segment(p1, q2, q1)) // p1, q1 and q2 are collinear and q2 lies on p1q1
+        || (o3 == 0 && on_segment(p2, p1, q2)) // p2, q2 and p1 are collinear and p1 lies on p2q2
+        || (o4 == 0 && on_segment(p2, q1, q2)) // p2, q2 and q1 are collinear and q1 lies on p2q2
+}
+
+/// check if a polygon diagonal intersects any polygon segments
+fn intersects_polygon<T: Float>(nodes: &[Node<T>], a: &Node<T>, b: &Node<T>) -> bool {
+    let mut p = a;
+    loop {
+        let p_next = node!(nodes, p.next_i);
+        if (p.i != a.i && p.i != b.i && p_next.i != a.i && p_next.i != b.i)
+            && intersects(p, p_next, a, b)
+        {
+            return true;
+        }
+        p = p_next;
+        if ptr::eq(p, a) {
+            return false;
+        }
+    }
+}
+
+/// check if the middle point of a polygon diagonal is inside the polygon
+fn middle_inside<T: Float>(nodes: &[Node<T>], a: &Node<T>, b: &Node<T>) -> bool {
+    let mut p = a;
+    let mut inside = false;
+    let two = T::one() + T::one();
+    let (px, py) = ((a.x + b.x) / two, (a.y + b.y) / two);
+    loop {
+        let p_next = node!(nodes, p.next_i);
+        inside ^= (p.y > py) != (p_next.y > py)
+            && p_next.y != p.y
+            && (px < (p_next.x - p.x) * (py - p.y) / (p_next.y - p.y) + p.x);
+        p = p_next;
+        if ptr::eq(p, a) {
+            return inside;
+        }
+    }
+}
+
+/// find a bridge between vertices that connects hole with an outer ring and and link it
+fn eliminate_hole<T: Float>(nodes: &mut Vec<Node<T>>, hole_i: u32, outer_node_i: u32) -> u32 {
+    let Some(bridge_i) = find_hole_bridge(nodes, node!(nodes, hole_i), outer_node_i) else {
+        return outer_node_i;
+    };
+    let bridge_reverse_i = split_polygon(nodes, bridge_i, hole_i);
+
+    // filter collinear points around the cuts
+    let end_i = Some(node!(nodes, bridge_reverse_i).next_i);
+    filter_points(nodes, bridge_reverse_i, end_i);
+    let end_i = Some(node!(nodes, bridge_i).next_i);
+    filter_points(nodes, bridge_i, end_i)
+}
+
+/// check if a polygon diagonal is locally inside the polygon
+fn locally_inside<T: Float>(nodes: &[Node<T>], a: &Node<T>, b: &Node<T>) -> bool {
+    let a_prev = node!(nodes, a.prev_i);
+    let a_next = node!(nodes, a.next_i);
+    if area(a_prev, a, a_next) < T::zero() {
+        area(a, b, a_next) >= T::zero() && area(a, a_prev, b) >= T::zero()
+    } else {
+        area(a, b, a_prev) < T::zero() || area(a, a_next, b) < T::zero()
+    }
+}
+
+/// dimavid Eberly's algorithm for finding a bridge between hole and outer polygon
+fn find_hole_bridge<T: Float>(nodes: &[Node<T>], hole: &Node<T>, outer_node_i: u32) -> Option<u32> {
+    let mut p_i = outer_node_i;
+    let mut qx = T::neg_infinity();
+    let mut m_i: Option<u32> = None;
+
+    // find a segment intersected by a ray from the hole's leftmost point to the left;
+    // segment's endpoint with lesser x will be potential connection point
+    loop {
+        let p = node!(nodes, p_i);
+        let p_next_i = p.next_i;
+        let p_next = node!(nodes, p_next_i);
+        if hole.y <= p.y && hole.y >= p_next.y && p_next.y != p.y {
+            let x = p.x + (hole.y - p.y) * (p_next.x - p.x) / (p_next.y - p.y);
+            if x <= hole.x && x > qx {
+                qx = x;
+                m_i = Some(if p.x < p_next.x { p_i } else { p_next_i });
+                if x == hole.x {
+                    // hole touches outer segment; pick leftmost endpoint
+                    return m_i;
+                }
+            }
+        }
+        p_i = p_next_i;
+        if p_i == outer_node_i {
+            break;
+        }
     }
 
-    /// check if two segments intersect
-    fn intersects(&self, p1: &Node<T>, q1: &Node<T>, p2: &Node<T>, q2: &Node<T>) -> bool {
-        let o1 = sign(area(p1, q1, p2));
-        let o2 = sign(area(p1, q1, q2));
-        let o3 = sign(area(p2, q2, p1));
-        let o4 = sign(area(p2, q2, q1));
-        (o1 != o2 && o3 != o4) // general case
-            || (o1 == 0 && on_segment(p1, p2, q1)) // p1, q1 and p2 are collinear and p2 lies on p1q1
-            || (o2 == 0 && on_segment(p1, q2, q1)) // p1, q1 and q2 are collinear and q2 lies on p1q1
-            || (o3 == 0 && on_segment(p2, p1, q2)) // p2, q2 and p1 are collinear and p1 lies on p2q2
-            || (o4 == 0 && on_segment(p2, q1, q2)) // p2, q2 and q1 are collinear and q1 lies on p2q2
-    }
+    let mut m_i = m_i?;
 
-    /// check if a polygon diagonal intersects any polygon segments
-    fn intersects_polygon(&self, a: &Node<T>, b: &Node<T>) -> bool {
-        let mut p = a;
-        loop {
-            let p_next = node!(self.nodes, p.next_i);
-            if (p.i != a.i && p.i != b.i && p_next.i != a.i && p_next.i != b.i)
-                && self.intersects(p, p_next, a, b)
+    // look for points inside the triangle of hole point, segment intersection and endpoint;
+    // if there are no points found, we have a valid connection;
+    // otherwise choose the point of the minimum angle with the ray as connection point
+
+    let stop_i = m_i;
+    let Node { x: mx, y: my, .. } = *node!(nodes, m_i); // must copy
+    let mut tan_min = T::infinity();
+
+    p_i = m_i;
+    let mut p = node!(nodes, p_i);
+    let mut m = p;
+
+    loop {
+        if (hole.x >= p.x && p.x >= mx && hole.x != p.x)
+            && point_in_triangle(
+                if hole.y < my { hole.x } else { qx },
+                hole.y,
+                mx,
+                my,
+                if hole.y < my { qx } else { hole.x },
+                hole.y,
+                p.x,
+                p.y,
+            )
+        {
+            let tan = (hole.y - p.y).abs() / (hole.x - p.x);
+            if locally_inside(nodes, p, hole)
+                && (tan < tan_min
+                    || (tan == tan_min
+                        && (p.x > m.x || p.x == m.x && sector_contains_sector(nodes, m, p))))
             {
-                return true;
-            }
-            p = p_next;
-            if ptr::eq(p, a) {
-                return false;
+                (m_i, m) = (p_i, p);
+                tan_min = tan;
             }
         }
-    }
 
-    /// check if a polygon diagonal is locally inside the polygon
-    fn locally_inside(&self, a: &Node<T>, b: &Node<T>) -> bool {
-        let a_prev = node!(self.nodes, a.prev_i);
-        let a_next = node!(self.nodes, a.next_i);
-        if area(a_prev, a, a_next) < T::zero() {
-            area(a, b, a_next) >= T::zero() && area(a, a_prev, b) >= T::zero()
+        p_i = p.next_i;
+        if p_i == stop_i {
+            return Some(m_i);
+        }
+        p = node!(nodes, p_i);
+    }
+}
+
+/// whether sector in vertex m contains sector in vertex p in the same coordinates
+fn sector_contains_sector<T: Float>(nodes: &[Node<T>], m: &Node<T>, p: &Node<T>) -> bool {
+    area(node!(nodes, m.prev_i), m, node!(nodes, p.prev_i)) < T::zero()
+        && area(node!(nodes, p.next_i), m, node!(nodes, m.next_i)) < T::zero()
+}
+
+/// eliminate colinear or duplicate points
+fn filter_points<T: Float>(nodes: &mut [Node<T>], start_i: u32, end_i: Option<u32>) -> u32 {
+    let mut end_i = end_i.unwrap_or(start_i);
+
+    let mut p_i = start_i;
+    loop {
+        let p = node!(nodes, p_i);
+        let p_next = node!(nodes, p.next_i);
+        if !p.steiner && (equals(p, p_next) || area(node!(nodes, p.prev_i), p, p_next).is_zero()) {
+            let (prev_i, next_i) = remove_node(nodes, p_i);
+            (p_i, end_i) = (prev_i, prev_i);
+            if p_i == next_i {
+                return end_i;
+            }
         } else {
-            area(a, b, a_prev) < T::zero() || area(a, a_next, b) < T::zero()
-        }
-    }
-
-    /// check if the middle point of a polygon diagonal is inside the polygon
-    fn middle_inside(&self, a: &Node<T>, b: &Node<T>) -> bool {
-        let mut p = a;
-        let mut inside = false;
-        let two = T::one() + T::one();
-        let (px, py) = ((a.x + b.x) / two, (a.y + b.y) / two);
-        loop {
-            let p_next = node!(self.nodes, p.next_i);
-            inside ^= (p.y > py) != (p_next.y > py)
-                && p_next.y != p.y
-                && (px < (p_next.x - p.x) * (py - p.y) / (p_next.y - p.y) + p.x);
-            p = p_next;
-            if ptr::eq(p, a) {
-                return inside;
+            p_i = p.next_i;
+            if p_i == end_i {
+                return end_i;
             }
-        }
+        };
     }
+}
 
-    /// link two polygon vertices with a bridge; if the vertices belong to the same ring, it splits polygon into two;
-    /// if one belongs to the outer ring and another to a hole, it merges it into a single ring
-    fn split_polygon(&mut self, a_i: u32, b_i: u32) -> u32 {
-        let a2_i = self.nodes.len() as u32;
-        let b2_i = a2_i + 1;
+/// link two polygon vertices with a bridge; if the vertices belong to the same ring, it splits polygon into two;
+/// if one belongs to the outer ring and another to a hole, it merges it into a single ring
+fn split_polygon<T: Float>(nodes: &mut Vec<Node<T>>, a_i: u32, b_i: u32) -> u32 {
+    let a2_i = nodes.len() as u32;
+    let b2_i = a2_i + 1;
 
-        let a = node_mut!(self.nodes, a_i);
-        let mut a2 = Node::new(a.i, a.x, a.y);
-        let an_i = a.next_i;
-        a.next_i = b_i;
-        a2.prev_i = b2_i;
-        a2.next_i = an_i;
+    let a = node_mut!(nodes, a_i);
+    let mut a2 = Node::new(a.i, a.x, a.y);
+    let an_i = a.next_i;
+    a.next_i = b_i;
+    a2.prev_i = b2_i;
+    a2.next_i = an_i;
+    node_mut!(nodes, an_i).prev_i = a2_i;
 
-        let b = node_mut!(self.nodes, b_i);
-        let mut b2 = Node::new(b.i, b.x, b.y);
-        let bp_i = b.prev_i;
-        b.prev_i = a_i;
-        b2.next_i = a2_i;
-        b2.prev_i = bp_i;
+    let b = node_mut!(nodes, b_i);
+    let mut b2 = Node::new(b.i, b.x, b.y);
+    let bp_i = b.prev_i;
+    b.prev_i = a_i;
+    b2.next_i = a2_i;
+    b2.prev_i = bp_i;
+    node_mut!(nodes, bp_i).next_i = b2_i;
 
-        node_mut!(self.nodes, an_i).prev_i = a2_i;
-        node_mut!(self.nodes, bp_i).next_i = b2_i;
+    nodes.extend([a2, b2]);
 
-        self.nodes.push(a2);
-        self.nodes.push(b2);
-
-        b2_i
-    }
+    b2_i
 }
 
 /// create a node and optionally link it with previous one (in a circular doubly linked list)
@@ -901,11 +904,12 @@ fn insert_node<T: Float>(nodes: &mut Vec<Node<T>>, i: u32, x: T, y: T, last: Opt
     let p_i = nodes.len() as u32;
     match last {
         Some(last_i) => {
-            let last_next_i = node!(nodes, last_i).next_i;
+            let last = node_mut!(nodes, last_i);
+            let last_next_i = last.next_i;
+            last.next_i = p_i;
             p.next_i = last_next_i;
             p.prev_i = last_i;
             node_mut!(nodes, last_next_i).prev_i = p_i;
-            node_mut!(nodes, last_i).next_i = p_i;
         }
         None => {
             (p.prev_i, p.next_i) = (p_i, p_i);
@@ -921,8 +925,10 @@ fn remove_node<T: Float>(nodes: &mut [Node<T>], p_i: u32) -> (u32, u32) {
     let p_prev_i = p.prev_i;
     let p_next_z_i = p.next_z_i;
     let p_prev_z_i = p.prev_z_i;
+
     node_mut!(nodes, p_next_i).prev_i = p_prev_i;
     node_mut!(nodes, p_prev_i).next_i = p_next_i;
+
     if let Some(prev_z_i) = p_prev_z_i {
         node_mut!(nodes, prev_z_i).next_z_i = p_next_z_i;
     }
@@ -945,17 +951,17 @@ pub fn deviation<T: Float, N: Index>(
     let outer_len = match has_holes {
         true => hole_indices[0].into_usize() * 2,
         false => data.len(),
-    };
-    let mut polygon_area = signed_area(&data, 0, outer_len as u32).abs();
+    } as u32;
+    let mut polygon_area = signed_area(&data, 0, outer_len).abs();
     if has_holes {
         for i in 0..hole_indices.len() {
-            let start = hole_indices[i].into_usize() * 2;
+            let start = hole_indices[i].into_usize() as u32 * 2;
             let end = if i < hole_indices.len() - 1 {
                 hole_indices[i + 1].into_usize() * 2
             } else {
                 data.len()
-            };
-            polygon_area = polygon_area - signed_area(&data, start as u32, end as u32).abs();
+            } as u32;
+            polygon_area = polygon_area - signed_area(&data, start, end).abs();
         }
     }
 
@@ -987,6 +993,7 @@ fn signed_area<T: Float>(data: &[T], start: u32, end: u32) -> T {
     let j = if end > 2 { end - 2 } else { 0 };
     let mut bx = data[j as usize];
     let mut by = data[(j + 1) as usize];
+
     let mut sum = T::zero();
     for a in data[start as usize..end as usize].chunks_exact(2) {
         let (ax, ay) = (a[0], a[1]);


### PR DESCRIPTION
> bad-hole                time:   [4.7701 µs 4.7764 µs 4.7843 µs]
>                         change: [-7.5315% -7.1720% -6.8299%] (p = 0.00 < 0.05)
> 
> building                time:   [210.68 ns 210.99 ns 211.39 ns]
>                         change: [-14.200% -13.938% -13.706%] (p = 0.00 < 0.05)
> 
> degenerate              time:   [51.923 ns 52.000 ns 52.095 ns]
>                         change: [-24.205% -23.925% -23.641%] (p = 0.00 < 0.05)
> 
> dude                    time:   [6.9004 µs 6.9139 µs 6.9285 µs]
>                         change: [-18.659% -18.323% -18.035%] (p = 0.00 < 0.05)
> 
> empty-square            time:   [88.237 ns 88.399 ns 88.602 ns]
>                         change: [-18.376% -18.025% -17.696%] (p = 0.00 < 0.05)
> 
> water                   time:   [680.86 µs 683.64 µs 686.74 µs]
>                         change: [-12.109% -11.628% -11.157%] (p = 0.00 < 0.05)
> 
> water2                  time:   [425.74 µs 429.01 µs 432.30 µs]
>                         change: [-27.032% -26.560% -26.016%] (p = 0.00 < 0.05)
> 
> water3                  time:   [20.170 µs 20.201 µs 20.238 µs]
>                         change: [-18.551% -18.249% -17.969%] (p = 0.00 < 0.05)
> 
> water3b                 time:   [1.4299 µs 1.4318 µs 1.4340 µs]
>                         change: [-14.272% -13.937% -13.597%] (p = 0.00 < 0.05)
> 
> water4                  time:   [116.44 µs 117.82 µs 119.52 µs]
>                         change: [-19.773% -18.881% -17.925%] (p = 0.00 < 0.05)
> 
> water-huge              time:   [11.871 ms 11.886 ms 11.903 ms]
>                         change: [-4.1979% -4.0088% -3.8230%] (p = 0.00 < 0.05)
> 
> water-huge2             time:   [24.799 ms 24.829 ms 24.861 ms]
>                         change: [-8.3678% -8.0259% -7.6721%] (p = 0.00 < 0.05)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added new benchmarks: "degenerate", "dude", "empty-square", "water4", "water-huge", and "water-huge2".
- **Bug Fixes**
	- Modified assertion logic in benchmark to ensure accuracy in triangle processing.
- **Chores**
	- Renamed a benchmark from "water" to "bad-hole".
	- Removed outdated benchmarks: "rain" and "hilbert".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->