### PR TITLE
Use stable sort

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "earcut"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 description = "A Rust port of the Earcut polygon triangulation library"
 authors = ["Taku Fukada <naninunenor@gmail.com>", "MIERUNE Inc. <info@mierune.co.jp>"]

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 A Rust port of the [mapbox/earcut](https://github.com/mapbox/earcut) polygon triangulation library, implemented from scratch with some reference to [donbright/earcutr](https://github.com/donbright/earcutr).
 
-- Based on the latest earcut 2.2.4 release.
-- Designed to avoid unnecessary memory allocations. You can reuse the internal buffer and the output index vector for multiple triangulations.
+- Based on the latest earcut 3.0.0 release.
+- Designed to avoid unnecessary memory allocations. The internal buffer and output index vector can be reused across multiple triangulations.
 - (Experimental) An additional module, `utils3d`, can rotate 3D coplanar polygons into the 2D plane before triangulation.
 - License: ISC
 
@@ -39,6 +39,5 @@ on Macbook Pro (M1 Pro)
 
 ## Authors
 
-- MIERUNE Inc.
 - Taku Fukada ([@ciscorn](https://github.com/ciscorn)) - original author
-
+- MIERUNE Inc.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,7 +288,7 @@ impl<T: Float> Earcut<T> {
         }
 
         self.queue
-            .sort_unstable_by(|(_a, ax), (_b, bx)| ax.partial_cmp(bx).unwrap_or(Ordering::Equal));
+            .sort_by(|(_a, ax), (_b, bx)| ax.partial_cmp(bx).unwrap_or(Ordering::Equal));
 
         // process holes from left to right
         for &(q, _) in &self.queue {

--- a/tests/fixture.rs
+++ b/tests/fixture.rs
@@ -27,7 +27,12 @@ fn test_fixture(name: &str, num_triangles: usize, expected_deviation: f64) {
     earcut.earcut(data.iter().copied(), &hole_indices, &mut triangles);
 
     // check
-    assert!(triangles.len() == num_triangles * 3);
+    assert!(
+        triangles.len() == num_triangles * 3,
+        "{} {}",
+        triangles.len(),
+        num_triangles * 3
+    );
     if !triangles.is_empty() {
         assert!(deviation(data.iter().copied(), &hole_indices, &triangles) <= expected_deviation);
     }
@@ -44,7 +49,7 @@ fn fixture_dude() {
 }
 
 #[test]
-fn fixture_water() {
+fn fixture_water1() {
     test_fixture("water", 2482, 0.0008);
 }
 
@@ -69,7 +74,7 @@ fn fixture_water4() {
 }
 
 #[test]
-fn fixture_water_huge() {
+fn fixture_water_huge1() {
     test_fixture("water-huge", 5177, 0.0011);
 }
 


### PR DESCRIPTION
- Use stable sort
    - Sorting algorithm has changed in Rust 1.81, causing test failures: [Rust 1.81.0 Release Notes](https://blog.rust-lang.org/2024/09/05/Rust-1.81.0.html#new-sort-implementations)
- Update README to reflect earcut(-js) 3.0.0 release: [earcut v3.0.0 Release](https://github.com/mapbox/earcut/releases/tag/v3.0.0)
    - Note: The triangulation algorithm remains unchanged from version 2.2.4.