### PR TITLE
fix: Remove `AsPrimitive<u32>` trait bound

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "earcut"
-version = "0.5.0"
+version = "0.4.9"
 edition = "2024"
 description = "A Rust port of the Earcut polygon triangulation library"
 authors = ["Taku Fukada <naninunenor@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -21,19 +21,19 @@ A Rust port of the [mapbox/earcut](https://github.com/mapbox/earcut) polygon tri
 
 Measured on a MacBook Pro (M1 Pro).
 
-| Polygon      | earcut.hpp  | earcut-rs (0.4.8) | earcutr (0.4.3) |
+| Polygon      | earcut.hpp  | earcut-rs (0.4.9) | earcutr (0.4.3) |
 |--------------|------------:|------------------:|----------------:|
-| bad_hole     |   3.55 µs/i |        2.661 µs/i |      4.415 µs/i |          
-| building     |    351 ns/i |          154 ns/i |        604 ns/i |
-| degenerate   |    154 ns/i |           38 ns/i |        206 ns/i |
-| dude         |   5.25 µs/i |        4.408 µs/i |      8.096 µs/i |
-| empty_square |    202 ns/i |           64 ns/i |        331 ns/i |
-| water        |    423 µs/i |        395.8 µs/i |      801.3 µs/i |
-| water2       |    338 µs/i |        271.9 µs/i |      450.3 µs/i |
-| water3       |   13.6 µs/i |        12.70 µs/i |      23.46 µs/i |
-| water3b      |   1.28 µs/i |        1.049 µs/i |      2.165 µs/i |
-| water4       |   89.1 µs/i |        71.45 µs/i |      154.1 µs/i |
-| water_huge   |  7.240 ms/i |        7.378 ms/i |      10.90 ms/i |
-| water_huge2  |  15.86 ms/i |        16.22 ms/i |      22.35 ms/i |
+| bad_hole     |   3.55 µs/i |        2.650 µs/i |      4.415 µs/i |          
+| building     |    351 ns/i |          155 ns/i |        604 ns/i |
+| degenerate   |    154 ns/i |           39 ns/i |        206 ns/i |
+| dude         |   5.25 µs/i |        4.535 µs/i |      8.096 µs/i |
+| empty_square |    202 ns/i |           66 ns/i |        331 ns/i |
+| water        |    423 µs/i |        400.9 µs/i |      801.3 µs/i |
+| water2       |    338 µs/i |        291.4 µs/i |      450.3 µs/i |
+| water3       |   13.6 µs/i |        13.03 µs/i |      23.46 µs/i |
+| water3b      |   1.28 µs/i |        1.057 µs/i |      2.165 µs/i |
+| water4       |   89.1 µs/i |        74.78 µs/i |      154.1 µs/i |
+| water_huge   |  7.240 ms/i |        7.456 ms/i |      10.90 ms/i |
+| water_huge2  |  15.86 ms/i |        16.26 ms/i |      22.35 ms/i |
 
 Note: earcut.hpp and earcutr have not fully caught up with the latest mapbox/earcut.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ pub mod utils3d;
 use alloc::vec::Vec;
 use core::{cmp::Ordering, num::NonZeroU32, ptr};
 
-use num_traits::{AsPrimitive, float::Float};
+use num_traits::float::Float;
 
 /// Index of a vertex
 pub trait Index: Copy {
@@ -150,19 +150,19 @@ impl<T: Float> Node<T> {
 }
 
 /// Instance of the earcut algorithm.
-pub struct Earcut<T: Float + AsPrimitive<u32>> {
+pub struct Earcut<T: Float> {
     data: Vec<[T; 2]>,
     nodes: Vec<Node<T>>,
     queue: Vec<(NodeOffset, T)>,
 }
 
-impl<T: Float + AsPrimitive<u32>> Default for Earcut<T> {
+impl<T: Float> Default for Earcut<T> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<T: Float + AsPrimitive<u32>> Earcut<T> {
+impl<T: Float> Earcut<T> {
     /// Creates a new instance of the earcut algorithm.
     ///
     /// You can reuse a single instance for multiple triangulations to reduce memory allocations.
@@ -350,7 +350,7 @@ enum Pass {
 
 /// main ear slicing loop which triangulates a polygon (given as a linked list)
 #[allow(clippy::too_many_arguments)]
-fn earcut_linked<T: Float + AsPrimitive<u32>, N: Index>(
+fn earcut_linked<T: Float, N: Index>(
     nodes: &mut Vec<Node<T>>,
     ear_i: NodeOffset,
     triangles: &mut Vec<N>,
@@ -460,7 +460,7 @@ fn is_ear<'a, T: Float>(
     (true, a, c)
 }
 
-fn is_ear_hashed<'a, T: Float + AsPrimitive<u32>>(
+fn is_ear_hashed<'a, T: Float>(
     nodes: &'a [Node<T>],
     ear: &'a Node<T>,
     min_x: T,
@@ -574,7 +574,7 @@ fn cure_local_intersections<T: Float, N: Index>(
 }
 
 /// try splitting polygon into two and triangulate them independently
-fn split_earcut<T: Float + AsPrimitive<u32>, N: Index>(
+fn split_earcut<T: Float, N: Index>(
     nodes: &mut Vec<Node<T>>,
     start_i: NodeOffset,
     triangles: &mut Vec<N>,
@@ -619,7 +619,7 @@ fn split_earcut<T: Float + AsPrimitive<u32>, N: Index>(
 }
 
 /// interlink polygon nodes in z-order
-fn index_curve<T: Float + AsPrimitive<u32>>(
+fn index_curve<T: Float>(
     nodes: &mut [Node<T>],
     start_i: NodeOffset,
     min_x: T,
@@ -1141,10 +1141,10 @@ fn signed_area<T: Float>(data: &[[T; 2]], start: usize, end: usize) -> T {
 }
 
 /// z-order of a point given coords and inverse of the longer side of data bbox
-fn z_order<T: Float + AsPrimitive<u32>>(xy: [T; 2], min_x: T, min_y: T, inv_size: T) -> i32 {
+fn z_order<T: Float>(xy: [T; 2], min_x: T, min_y: T, inv_size: T) -> i32 {
     // coords are transformed into non-negative 15-bit integer range
-    let x: u32 = ((xy[0] - min_x) * inv_size).as_();
-    let y: u32 = ((xy[1] - min_y) * inv_size).as_();
+    let x = ((xy[0] - min_x) * inv_size).to_u32().unwrap();
+    let y = ((xy[1] - min_y) * inv_size).to_u32().unwrap();
     let mut xy = (x as i64) << 32 | y as i64;
     xy = (xy | (xy << 8)) & 0x00FF00FF00FF00FF;
     xy = (xy | (xy << 4)) & 0x0F0F0F0F0F0F0F0F;


### PR DESCRIPTION
Related #27 

Removes the `AsPrimitive<u32>` trait bound from the public API and restores `Earcut<T>` to `T: Float`.

While the extra bound provided a small performance benefit in some cases, it also made the crate harder to use from other crates.