### PR TITLE
refactor: consolidate unsafe node access helpers

### DIFF
--- a/src/int.rs
+++ b/src/int.rs
@@ -4,7 +4,9 @@
 //! floating-point rounding errors of [`crate::Earcut`].
 
 use alloc::vec::Vec;
-use core::{num::NonZeroU32, ptr};
+use core::{cmp::Ordering, num::NonZeroU32, ptr};
+
+use crate::node_offset;
 
 #[inline(always)]
 fn use_small_path(range_x: i64, range_y: i64) -> bool {
@@ -141,44 +143,6 @@ fn signed_area(data: &[[i32; 2]], start: usize, end: usize) -> i64 {
 /// Sentinel `shift` value signaling "no z-order hashing" for this run.
 const NO_HASH: u32 = u32::MAX;
 
-macro_rules! node {
-    ($self:ident.$nodes:ident, $offset:expr) => {
-        unsafe {
-            let off = $offset.get() as usize;
-            debug_assert!(off % core::mem::size_of_val(&$self.$nodes[0]) == 0);
-            debug_assert!(off / core::mem::size_of_val(&$self.$nodes[0]) < $self.$nodes.len());
-            &*$self.$nodes.as_ptr().byte_add(off)
-        }
-    };
-    ($nodes:ident, $offset:expr) => {
-        unsafe {
-            let off = $offset.get() as usize;
-            debug_assert!(off % core::mem::size_of_val(&$nodes[0]) == 0);
-            debug_assert!(off / core::mem::size_of_val(&$nodes[0]) < $nodes.len());
-            &*$nodes.as_ptr().byte_add(off)
-        }
-    };
-}
-
-macro_rules! node_mut {
-    ($self:ident.$nodes:ident, $offset:expr) => {
-        unsafe {
-            let off = $offset.get() as usize;
-            debug_assert!(off % core::mem::size_of_val(&$self.$nodes[0]) == 0);
-            debug_assert!(off / core::mem::size_of_val(&$self.$nodes[0]) < $self.$nodes.len());
-            &mut *$self.$nodes.as_mut_ptr().byte_add(off)
-        }
-    };
-    ($nodes:ident, $offset:expr) => {
-        unsafe {
-            let off = $offset.get() as usize;
-            debug_assert!(off % core::mem::size_of_val(&$nodes[0]) == 0);
-            debug_assert!(off / core::mem::size_of_val(&$nodes[0]) < $nodes.len());
-            &mut *$nodes.as_mut_ptr().byte_add(off)
-        }
-    };
-}
-
 /// Byte offset (from `nodes` base pointer) of a `Node` in the `nodes` Vec.
 type NodeOffset = NonZeroU32;
 
@@ -238,14 +202,16 @@ impl InputBbox {
 }
 
 impl Node {
+    const PLACEHOLDER_OFFSET: NodeOffset =
+        NodeOffset::new(core::mem::size_of::<Self>() as u32).unwrap();
+
     fn new(i: u32, xy: [i32; 2]) -> Self {
         debug_assert!(i & STEINER_BIT == 0);
-        let placeholder = unsafe { NodeOffset::new_unchecked(core::mem::size_of::<Self>() as u32) };
         Self {
             i_steiner: i,
             xy,
-            prev_i: placeholder,
-            next_i: placeholder,
+            prev_i: Self::PLACEHOLDER_OFFSET,
+            next_i: Self::PLACEHOLDER_OFFSET,
             z: 0,
             prev_z_i: None,
             next_z_i: None,
@@ -1018,9 +984,8 @@ fn filter_points(nodes: &mut [Node], start_i: NodeOffset, end_i: Option<NodeOffs
 /// if one belongs to the outer ring and another to a hole, it merges it into a single ring
 fn split_polygon(nodes: &mut Vec<Node>, a_i: NodeOffset, b_i: NodeOffset) -> NodeOffset {
     debug_assert!(!nodes.is_empty());
-    let stride = core::mem::size_of::<Node>() as u32;
-    let a2_i = unsafe { NodeOffset::new_unchecked(nodes.len() as u32 * stride) };
-    let b2_i = unsafe { NodeOffset::new_unchecked((nodes.len() as u32 + 1) * stride) };
+    let a2_i = node_offset::<Node>(nodes.len());
+    let b2_i = node_offset::<Node>(nodes.len() + 1);
 
     let a = node_mut!(nodes, a_i);
     let mut a2 = Node::new(a.index(), a.xy);
@@ -1052,8 +1017,7 @@ fn insert_node(
     last: Option<NodeOffset>,
 ) -> NodeOffset {
     let mut p = Node::new(i, xy);
-    let stride = core::mem::size_of::<Node>() as u32;
-    let p_i = unsafe { NodeOffset::new_unchecked(nodes.len() as u32 * stride) };
+    let p_i = node_offset::<Node>(nodes.len());
     match last {
         Some(last_i) => {
             let last = node_mut!(nodes, last_i);
@@ -1151,8 +1115,6 @@ fn on_segment(p: &Node, q: &Node, r: &Node) -> bool {
     ((q.xy[0] <= p.xy[0].max(r.xy[0])) & (q.xy[1] <= p.xy[1].max(r.xy[1])))
         && ((q.xy[0] >= p.xy[0].min(r.xy[0])) & (q.xy[1] >= p.xy[1].min(r.xy[1])))
 }
-
-use core::cmp::Ordering;
 
 /// Integer earcut specialized for `i32` coordinates.
 pub struct EarcutI32 {
@@ -1304,8 +1266,8 @@ impl EarcutI32 {
                 Ordering::Equal => {}
                 ordering => return ordering,
             }
-            let a = node!(self.nodes, ai);
-            let b = node!(self.nodes, bi);
+            let a = node!(self.nodes, *ai);
+            let b = node!(self.nodes, *bi);
             match a.xy[1].cmp(&b.xy[1]) {
                 Ordering::Equal => {}
                 ordering => return ordering,

--- a/src/int.rs
+++ b/src/int.rs
@@ -129,6 +129,7 @@ pub fn deviation<N: Index>(
 
 /// signed area of a polygon ring (twice the geometric area)
 fn signed_area(data: &[[i32; 2]], start: usize, end: usize) -> i64 {
+    assert!(end > 0 && start <= end && end <= data.len());
     let [mut bx, mut by] = [data[end - 1][0] as i64, data[end - 1][1] as i64];
     let mut sum = 0;
     for &[ax_r, ay_r] in &data[start..end] {
@@ -1060,6 +1061,7 @@ fn remove_node(nodes: &mut [Node], pl: LinkInfo) -> (NodeOffset, NodeOffset) {
 
 #[inline]
 fn input_bbox(data: &[[i32; 2]], start: usize, end: usize) -> InputBbox {
+    assert!(start < end && end <= data.len());
     let mut bbox = InputBbox::new(data[start]);
     for &xy in &data[start..end] {
         bbox.update(xy);
@@ -1216,6 +1218,7 @@ impl EarcutI32 {
     }
 
     fn linked_list(&mut self, start: usize, end: usize, clockwise: bool) -> Option<NodeOffset> {
+        assert!(start <= end && end <= self.data.len());
         let mut last_i = None;
         let iter = self.data[start..end].iter().enumerate();
         if clockwise == (signed_area(&self.data, start, end) > 0) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,9 @@ impl Index for usize {
     }
 }
 
-/// Byte offset (from `nodes` base pointer) of a node in the nodes Vec.
+/// Byte offset of a node in the nodes Vec.
+///
+/// Non-zero so `Option<NodeOffset>` keeps `Node` small.
 type NodeOffset = NonZeroU32;
 
 /// # Safety
@@ -91,8 +93,8 @@ unsafe fn node_at<N>(nodes: &[N], offset: NodeOffset) -> &N {
     debug_assert!(stride > 0);
     debug_assert!(off.is_multiple_of(stride));
     debug_assert!(off / stride < nodes.len());
-    // SAFETY: the caller guarantees that `offset` points to a valid element in
-    // `nodes`; see the safety contract above.
+    // SAFETY: the caller guarantees that `offset` is valid for `nodes`;
+    // see the safety contract above.
     unsafe { &*nodes.as_ptr().byte_add(off) }
 }
 
@@ -107,14 +109,16 @@ unsafe fn node_at_mut<N>(nodes: &mut [N], offset: NodeOffset) -> &mut N {
     debug_assert!(stride > 0);
     debug_assert!(off.is_multiple_of(stride));
     debug_assert!(off / stride < nodes.len());
-    // SAFETY: the caller guarantees that `offset` points to a valid element in
-    // `nodes`; see the safety contract above.
+    // SAFETY: the caller guarantees that `offset` is valid for `nodes`;
+    // see the safety contract above.
     unsafe { &mut *nodes.as_mut_ptr().byte_add(off) }
 }
 
+/// Creates a byte offset for a real node.
+///
+/// Index 0 is the dummy node, so real node offsets are non-zero.
 #[inline(always)]
 fn node_offset<N>(index: usize) -> NodeOffset {
-    // Index 0 is the dummy node. Real node offsets are non-zero.
     let stride = core::mem::size_of::<N>();
     assert!(index > 0 && index <= u32::MAX as usize / stride);
     let byte_offset = (index * stride) as u32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,6 +287,7 @@ impl<T: Float> Earcut<T> {
 
     /// create a circular doubly linked list from polygon points in the specified winding order
     fn linked_list(&mut self, start: usize, end: usize, clockwise: bool) -> Option<NodeOffset> {
+        assert!(start <= end && end <= self.data.len());
         let mut last_i: Option<NodeOffset> = None;
         let iter = self.data[start..end].iter().enumerate();
 
@@ -1158,6 +1159,7 @@ pub fn deviation<T: Float, N: Index>(
 
 /// check if a point lies within a convex triangle
 fn signed_area<T: Float>(data: &[[T; 2]], start: usize, end: usize) -> T {
+    assert!(end > 0 && start <= end && end <= data.len());
     let [mut bx, mut by] = data[end - 1];
     let mut sum = T::zero();
     for &[ax, ay] in &data[start..end] {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,11 +103,10 @@ unsafe fn node_at_mut<N>(nodes: &mut [N], offset: NodeOffset) -> &mut N {
 #[inline(always)]
 fn node_offset<N>(index: usize) -> NodeOffset {
     // Index 0 is the dummy node. Real node offsets are non-zero.
-    debug_assert!(index > 0);
     let stride = core::mem::size_of::<N>();
-    assert!(index <= u32::MAX as usize / stride);
+    assert!(index > 0 && index <= u32::MAX as usize / stride);
     let byte_offset = (index * stride) as u32;
-    unsafe { NodeOffset::new_unchecked(byte_offset) }
+    NodeOffset::new(byte_offset).unwrap()
 }
 
 const STEINER_BIT: u32 = 1 << 31;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,8 @@ type NodeOffset = NonZeroU32;
 ///
 /// In this crate, this holds because:
 ///
-/// - each offset is created with `node_offset::<N>` from an index into the same nodes Vec.
+/// - each offset is created with `node_offset::<N>` and is only used after its
+///   node has been appended.
 /// - nodes are only appended to the Vec and are never removed or reordered, so
 ///   each offset keeps identifying the same node.
 /// - offsets are byte offsets, not raw pointers. Each access adds the offset to
@@ -93,6 +94,7 @@ unsafe fn node_at<N>(nodes: &[N], offset: NodeOffset) -> &N {
 unsafe fn node_at_mut<N>(nodes: &mut [N], offset: NodeOffset) -> &mut N {
     let off = offset.get() as usize;
     let stride = core::mem::size_of::<N>();
+    debug_assert!(stride > 0);
     debug_assert!(off.is_multiple_of(stride));
     debug_assert!(off / stride < nodes.len());
     unsafe { &mut *nodes.as_mut_ptr().byte_add(off) }
@@ -100,10 +102,12 @@ unsafe fn node_at_mut<N>(nodes: &mut [N], offset: NodeOffset) -> &mut N {
 
 #[inline(always)]
 fn node_offset<N>(index: usize) -> NodeOffset {
+    // Index 0 is the dummy node. Real node offsets are non-zero.
+    debug_assert!(index > 0);
     let stride = core::mem::size_of::<N>();
     assert!(index <= u32::MAX as usize / stride);
     let byte_offset = (index * stride) as u32;
-    NodeOffset::new(byte_offset).expect("node byte offset must be non-zero")
+    unsafe { NodeOffset::new_unchecked(byte_offset) }
 }
 
 const STEINER_BIT: u32 = 1 << 31;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,13 +3,31 @@
 #![no_std]
 extern crate alloc;
 
-pub mod int;
-pub mod utils3d;
-
 use alloc::vec::Vec;
 use core::{cmp::Ordering, num::NonZeroU32, ptr};
 
 use num_traits::float::Float;
+
+macro_rules! node {
+    ($self:ident.$nodes:ident, $offset:expr) => {
+        unsafe { $crate::node_at(&$self.$nodes, $offset) }
+    };
+    ($nodes:ident, $offset:expr) => {
+        unsafe { $crate::node_at($nodes, $offset) }
+    };
+}
+
+macro_rules! node_mut {
+    ($self:ident.$nodes:ident, $offset:expr) => {
+        unsafe { $crate::node_at_mut(&mut $self.$nodes, $offset) }
+    };
+    ($nodes:ident, $offset:expr) => {
+        unsafe { $crate::node_at_mut($nodes, $offset) }
+    };
+}
+
+pub mod int;
+pub mod utils3d;
 
 /// Index of a vertex
 pub trait Index: Copy {
@@ -41,46 +59,52 @@ impl Index for usize {
     }
 }
 
-macro_rules! node {
-    ($self:ident.$nodes:ident, $offset:expr) => {
-        unsafe {
-            let off = $offset.get() as usize;
-            debug_assert!(off % core::mem::size_of_val(&$self.$nodes[0]) == 0);
-            debug_assert!(off / core::mem::size_of_val(&$self.$nodes[0]) < $self.$nodes.len());
-            &*$self.$nodes.as_ptr().byte_add(off)
-        }
-    };
-    ($nodes:ident, $offset:expr) => {
-        unsafe {
-            let off = $offset.get() as usize;
-            debug_assert!(off % core::mem::size_of_val(&$nodes[0]) == 0);
-            debug_assert!(off / core::mem::size_of_val(&$nodes[0]) < $nodes.len());
-            &*$nodes.as_ptr().byte_add(off)
-        }
-    };
-}
-
-macro_rules! node_mut {
-    ($self:ident.$nodes:ident, $offset:expr) => {
-        unsafe {
-            let off = $offset.get() as usize;
-            debug_assert!(off % core::mem::size_of_val(&$self.$nodes[0]) == 0);
-            debug_assert!(off / core::mem::size_of_val(&$self.$nodes[0]) < $self.$nodes.len());
-            &mut *$self.$nodes.as_mut_ptr().byte_add(off)
-        }
-    };
-    ($nodes:ident, $offset:expr) => {
-        unsafe {
-            let off = $offset.get() as usize;
-            debug_assert!(off % core::mem::size_of_val(&$nodes[0]) == 0);
-            debug_assert!(off / core::mem::size_of_val(&$nodes[0]) < $nodes.len());
-            &mut *$nodes.as_mut_ptr().byte_add(off)
-        }
-    };
-}
-
-/// Byte offset (from `nodes` base pointer) of a `Node<T>` in the `nodes` Vec.
+/// Byte offset (from `nodes` base pointer) of a node in the nodes Vec.
 type NodeOffset = NonZeroU32;
+
+/// # Safety
+///
+/// `offset` must point to a valid element in `nodes`.
+///
+/// In this crate, this holds because:
+///
+/// - each offset is created with `node_offset::<N>` from an index into the same nodes Vec.
+/// - nodes are only appended to the Vec and are never removed or reordered, so
+///   each offset keeps identifying the same node.
+/// - offsets are byte offsets, not raw pointers. Each access adds the offset to
+///   the current `nodes.as_ptr()`, so Vec reallocation does not make offsets
+///   invalid.
+/// - `node_offset` checks that the byte offset fits in `u32`.
+#[inline(always)]
+unsafe fn node_at<N>(nodes: &[N], offset: NodeOffset) -> &N {
+    let off = offset.get() as usize;
+    let stride = core::mem::size_of::<N>();
+    debug_assert!(stride > 0);
+    debug_assert!(off.is_multiple_of(stride));
+    debug_assert!(off / stride < nodes.len());
+    unsafe { &*nodes.as_ptr().byte_add(off) }
+}
+
+/// # Safety
+///
+/// `offset` must point to a valid element in `nodes`. See `node_at` for the
+/// full invariant.
+#[inline(always)]
+unsafe fn node_at_mut<N>(nodes: &mut [N], offset: NodeOffset) -> &mut N {
+    let off = offset.get() as usize;
+    let stride = core::mem::size_of::<N>();
+    debug_assert!(off.is_multiple_of(stride));
+    debug_assert!(off / stride < nodes.len());
+    unsafe { &mut *nodes.as_mut_ptr().byte_add(off) }
+}
+
+#[inline(always)]
+fn node_offset<N>(index: usize) -> NodeOffset {
+    let stride = core::mem::size_of::<N>();
+    assert!(index <= u32::MAX as usize / stride);
+    let byte_offset = (index * stride) as u32;
+    NodeOffset::new(byte_offset).expect("node byte offset must be non-zero")
+}
 
 const STEINER_BIT: u32 = 1 << 31;
 const INDEX_MASK: u32 = !STEINER_BIT;
@@ -110,14 +134,16 @@ struct LinkInfo {
 }
 
 impl<T: Float> Node<T> {
+    const PLACEHOLDER_OFFSET: NodeOffset =
+        NodeOffset::new(core::mem::size_of::<Self>() as u32).unwrap();
+
     fn new(i: u32, xy: [T; 2]) -> Self {
         debug_assert!(i & STEINER_BIT == 0);
-        let placeholder = unsafe { NodeOffset::new_unchecked(core::mem::size_of::<Self>() as u32) };
         Self {
             i_steiner: i,
             xy,
-            prev_i: placeholder,
-            next_i: placeholder,
+            prev_i: Self::PLACEHOLDER_OFFSET,
+            next_i: Self::PLACEHOLDER_OFFSET,
             z: 0,
             prev_z_i: None,
             next_z_i: None,
@@ -318,8 +344,8 @@ impl<T: Float> Earcut<T> {
             }
             // when the left-most point of 2 holes meet at a vertex, sort the holes counterclockwise so that when we find
             // the bridge to the outer shell is always the point that they meet at.
-            let a = node!(self.nodes, ai);
-            let b = node!(self.nodes, bi);
+            let a = node!(self.nodes, *ai);
+            let b = node!(self.nodes, *bi);
             match a.xy[1].partial_cmp(&b.xy[1]) {
                 Some(Ordering::Equal) => {}
                 Some(ordering) => return ordering,
@@ -1000,9 +1026,8 @@ fn split_polygon<T: Float>(
     b_i: NodeOffset,
 ) -> NodeOffset {
     debug_assert!(!nodes.is_empty());
-    let stride = core::mem::size_of::<Node<T>>() as u32;
-    let a2_i = unsafe { NodeOffset::new_unchecked(nodes.len() as u32 * stride) };
-    let b2_i = unsafe { NodeOffset::new_unchecked((nodes.len() as u32 + 1) * stride) };
+    let a2_i = node_offset::<Node<T>>(nodes.len());
+    let b2_i = node_offset::<Node<T>>(nodes.len() + 1);
 
     let a = node_mut!(nodes, a_i);
     let mut a2 = Node::new(a.index(), a.xy);
@@ -1034,8 +1059,7 @@ fn insert_node<T: Float>(
     last: Option<NodeOffset>,
 ) -> NodeOffset {
     let mut p = Node::new(i, xy);
-    let stride = core::mem::size_of::<Node<T>>() as u32;
-    let p_i = unsafe { NodeOffset::new_unchecked(nodes.len() as u32 * stride) };
+    let p_i = node_offset::<Node<T>>(nodes.len());
     match last {
         Some(last_i) => {
             let last = node_mut!(nodes, last_i);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,18 +10,26 @@ use num_traits::float::Float;
 
 macro_rules! node {
     ($self:ident.$nodes:ident, $offset:expr) => {
+        // SAFETY: all `NodeOffset`s used by this crate follow the invariant
+        // documented on `node_at`.
         unsafe { $crate::node_at(&$self.$nodes, $offset) }
     };
     ($nodes:ident, $offset:expr) => {
+        // SAFETY: all `NodeOffset`s used by this crate follow the invariant
+        // documented on `node_at`.
         unsafe { $crate::node_at($nodes, $offset) }
     };
 }
 
 macro_rules! node_mut {
     ($self:ident.$nodes:ident, $offset:expr) => {
+        // SAFETY: all `NodeOffset`s used by this crate follow the invariant
+        // documented on `node_at_mut`.
         unsafe { $crate::node_at_mut(&mut $self.$nodes, $offset) }
     };
     ($nodes:ident, $offset:expr) => {
+        // SAFETY: all `NodeOffset`s used by this crate follow the invariant
+        // documented on `node_at_mut`.
         unsafe { $crate::node_at_mut($nodes, $offset) }
     };
 }
@@ -83,6 +91,8 @@ unsafe fn node_at<N>(nodes: &[N], offset: NodeOffset) -> &N {
     debug_assert!(stride > 0);
     debug_assert!(off.is_multiple_of(stride));
     debug_assert!(off / stride < nodes.len());
+    // SAFETY: the caller guarantees that `offset` points to a valid element in
+    // `nodes`; see the safety contract above.
     unsafe { &*nodes.as_ptr().byte_add(off) }
 }
 
@@ -97,6 +107,8 @@ unsafe fn node_at_mut<N>(nodes: &mut [N], offset: NodeOffset) -> &mut N {
     debug_assert!(stride > 0);
     debug_assert!(off.is_multiple_of(stride));
     debug_assert!(off / stride < nodes.len());
+    // SAFETY: the caller guarantees that `offset` points to a valid element in
+    // `nodes`; see the safety contract above.
     unsafe { &mut *nodes.as_mut_ptr().byte_add(off) }
 }
 


### PR DESCRIPTION
Relates to #35.

Makes the unsafe node access code smaller and easier to review.

- Consolidates the node access helpers and macros shared by the float and integer implementations.
- Documents why the byte offsets are safe to use.

---
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to the project's change log file if knowledge of this change could be valuable to users.
  - Usually called `CHANGES.md` or `CHANGELOG.md`
  - Prefix changelog entries for breaking changes with "BREAKING: "

