### PR TITLE
perf: bbox prechecks and Vec-based z-order sort

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
 
   release:
     name: Release-plz release
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'georust'
     needs: test
     runs-on: ubuntu-latest
     concurrency:
@@ -51,16 +51,39 @@ jobs:
       id-token: write
       pull-requests: read
     steps:
-      - name: Checkout repository
+      - &checkout
+        name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Install Rust toolchain
+      - &install-rust
+        name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Run release-plz
         uses: release-plz/action@d5a2b630feb35385893823d8e2b82aa955218b74
         with:
           command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release-pr:
+    name: Release-plz PR
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'georust'
+    needs: test
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-plz-pr-${{ github.ref }}
+      cancel-in-progress: false
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - *checkout
+      - *install-rust
+      - name: Run release-plz
+        uses: release-plz/action@d5a2b630feb35385893823d8e2b82aa955218b74
+        with:
+          command: release-pr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# earcut-rs
+# earcut (Rust)
 
 [![CI](https://github.com/georust/earcut/actions/workflows/ci.yml/badge.svg)](https://github.com/georust/earcut/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/georust/earcut/graph/badge.svg)](https://codecov.io/gh/georust/earcut)
@@ -20,22 +20,22 @@ A Rust port of the [mapbox/earcut](https://github.com/mapbox/earcut) polygon tri
 
 Measured on a MacBook Pro (M1 Pro).
 
-| Polygon      | earcut.hpp  | earcut-rs (0.4.9) | earcutr (0.4.3) |
-|--------------|------------:|------------------:|----------------:|
-| bad_hole     |   3.55 µs/i |        2.650 µs/i |      4.415 µs/i |          
-| building     |    351 ns/i |          155 ns/i |        604 ns/i |
-| degenerate   |    154 ns/i |           39 ns/i |        206 ns/i |
-| dude         |   5.25 µs/i |        4.535 µs/i |      8.096 µs/i |
-| empty_square |    202 ns/i |           66 ns/i |        331 ns/i |
-| water        |    423 µs/i |        400.9 µs/i |      801.3 µs/i |
-| water2       |    338 µs/i |        291.4 µs/i |      450.3 µs/i |
-| water3       |   13.6 µs/i |        13.03 µs/i |      23.46 µs/i |
-| water3b      |   1.28 µs/i |        1.057 µs/i |      2.165 µs/i |
-| water4       |   89.1 µs/i |        74.78 µs/i |      154.1 µs/i |
-| water_huge   |  7.240 ms/i |        7.456 ms/i |      10.90 ms/i |
-| water_huge2  |  15.86 ms/i |        16.26 ms/i |      22.35 ms/i |
+| Polygon      | earcut.hpp (C++) | earcut (Rust) | earcutr (Rust) |
+|--------------|-----------------:|--------------:|---------------:|
+| bad_hole     |        3.53 µs/i |    2.712 µs/i |     4.415 µs/i |
+| building     |         351 ns/i |      157 ns/i |       604 ns/i |
+| degenerate   |         153 ns/i |       41 ns/i |       206 ns/i |
+| dude         |        5.21 µs/i |    4.204 µs/i |     8.096 µs/i |
+| empty_square |         201 ns/i |       67 ns/i |       331 ns/i |
+| water        |         420 µs/i |    345.8 µs/i |     801.3 µs/i |
+| water2       |         338 µs/i |    249.7 µs/i |     450.3 µs/i |
+| water3       |        13.5 µs/i |    11.91 µs/i |     23.46 µs/i |
+| water3b      |        1.27 µs/i |    1.087 µs/i |     2.165 µs/i |
+| water4       |        88.9 µs/i |    67.40 µs/i |     154.1 µs/i |
+| water_huge   |       6.674 ms/i |    7.059 ms/i |     10.90 ms/i |
+| water_huge2  |       15.23 ms/i |    14.82 ms/i |     22.35 ms/i |
 
-Note: earcut.hpp and earcutr have not fully caught up with the latest mapbox/earcut.
+Note: [earcut.hpp](https://github.com/mapbox/earcut.hpp) and [earcutr](https://github.com/frewsxcv/earcutr) have not fully caught up with the latest [mapbox/earcut](https://github.com/mapbox/earcut).
 
 ## License
 

--- a/src/int.rs
+++ b/src/int.rs
@@ -89,7 +89,7 @@ pub fn deviation<N: Index>(
     let polygon_area = if data.len() < 3 {
         0
     } else {
-        let mut polygon_area = signed_area(&data, 0, outer_len).abs();
+        let mut polygon_area = signed_area(&data[..outer_len]).abs();
         if has_holes {
             for i in 0..hole_indices.len() {
                 let start = hole_indices[i].into_usize();
@@ -99,7 +99,7 @@ pub fn deviation<N: Index>(
                     data.len()
                 };
                 if end - start >= 3 {
-                    polygon_area -= signed_area(&data, start, end).abs();
+                    polygon_area -= signed_area(&data[start..end]).abs();
                 }
             }
         }
@@ -128,11 +128,12 @@ pub fn deviation<N: Index>(
 }
 
 /// signed area of a polygon ring (twice the geometric area)
-fn signed_area(data: &[[i32; 2]], start: usize, end: usize) -> i64 {
-    assert!(end > 0 && start <= end && end <= data.len());
-    let [mut bx, mut by] = [data[end - 1][0] as i64, data[end - 1][1] as i64];
+fn signed_area(data: &[[i32; 2]]) -> i64 {
+    debug_assert!(!data.is_empty());
+    let [last_x, last_y] = data[data.len() - 1];
+    let [mut bx, mut by] = [last_x as i64, last_y as i64];
     let mut sum = 0;
-    for &[ax_r, ay_r] in &data[start..end] {
+    for &[ax_r, ay_r] in data {
         let ax = ax_r as i64;
         let ay = ay_r as i64;
         sum += (bx - ax) * (ay + by);
@@ -261,13 +262,14 @@ fn earcut_linked<N: Index>(
     min_y: i32,
     shift: u32,
     small_path: bool,
+    sort_queue: &mut Vec<(i32, NodeOffset)>,
     pass: Pass,
 ) {
     let mut ear_i = ear_i;
 
     // interlink polygon nodes in z-order
     if pass == Pass::P0 && shift != NO_HASH {
-        index_curve(nodes, ear_i, min_x, min_y, shift);
+        index_curve(nodes, ear_i, min_x, min_y, shift, sort_queue);
     }
 
     let mut stop_i = ear_i;
@@ -315,6 +317,7 @@ fn earcut_linked<N: Index>(
                     min_y,
                     shift,
                     small_path,
+                    sort_queue,
                     Pass::P1,
                 );
             } else if pass == Pass::P1 {
@@ -328,10 +331,13 @@ fn earcut_linked<N: Index>(
                     min_y,
                     shift,
                     small_path,
+                    sort_queue,
                     Pass::P2,
                 );
-            } else if pass == Pass::P2 {
-                split_earcut(nodes, ear_i, triangles, min_x, min_y, shift, small_path);
+            } else {
+                split_earcut(
+                    nodes, ear_i, triangles, min_x, min_y, shift, small_path, sort_queue,
+                );
             }
             return;
         }
@@ -526,6 +532,7 @@ fn cure_local_intersections<N: Index>(
 }
 
 /// try splitting polygon into two and triangulate them independently
+#[allow(clippy::too_many_arguments)]
 fn split_earcut<N: Index>(
     nodes: &mut Vec<Node>,
     start_i: NodeOffset,
@@ -534,6 +541,7 @@ fn split_earcut<N: Index>(
     min_y: i32,
     shift: u32,
     small_path: bool,
+    sort_queue: &mut Vec<(i32, NodeOffset)>,
 ) {
     // look for a valid diagonal that divides the polygon into two
     let mut ai = start_i;
@@ -541,11 +549,12 @@ fn split_earcut<N: Index>(
     loop {
         let a_next = node!(nodes, a.next_i);
         let a_prev = node!(nodes, a.prev_i);
+        let a_index = a.index();
         let mut bi = a_next.next_i;
 
         while bi != a.prev_i {
             let b = node!(nodes, bi);
-            if a.index() != b.index() && is_valid_diagonal(nodes, a, b, a_next, a_prev) {
+            if a_index != b.index() && is_valid_diagonal(nodes, a, b, a_next, a_prev) {
                 // split the polygon in two by the diagonal
                 let mut ci = split_polygon(nodes, ai, bi);
 
@@ -564,6 +573,7 @@ fn split_earcut<N: Index>(
                     min_y,
                     shift,
                     small_path,
+                    sort_queue,
                     Pass::P0,
                 );
                 earcut_linked(
@@ -574,6 +584,7 @@ fn split_earcut<N: Index>(
                     min_y,
                     shift,
                     small_path,
+                    sort_queue,
                     Pass::P0,
                 );
                 return;
@@ -590,7 +601,15 @@ fn split_earcut<N: Index>(
 }
 
 /// interlink polygon nodes in z-order
-fn index_curve(nodes: &mut [Node], start_i: NodeOffset, min_x: i32, min_y: i32, shift: u32) {
+fn index_curve(
+    nodes: &mut [Node],
+    start_i: NodeOffset,
+    min_x: i32,
+    min_y: i32,
+    shift: u32,
+    order: &mut Vec<(i32, NodeOffset)>,
+) {
+    order.clear();
     let mut p_i = start_i;
     let mut p = node_mut!(nodes, p_i);
 
@@ -598,8 +617,7 @@ fn index_curve(nodes: &mut [Node], start_i: NodeOffset, min_x: i32, min_y: i32, 
         if p.z == 0 {
             p.z = z_order(p.xy, min_x, min_y, shift);
         }
-        p.prev_z_i = Some(p.prev_i);
-        p.next_z_i = Some(p.next_i);
+        order.push((p.z, p_i));
         p_i = p.next_i;
         p = node_mut!(nodes, p_i);
         if p_i == start_i {
@@ -607,99 +625,18 @@ fn index_curve(nodes: &mut [Node], start_i: NodeOffset, min_x: i32, min_y: i32, 
         }
     }
 
-    let p_prev_z_i = p.prev_z_i.take().unwrap();
-    node_mut!(nodes, p_prev_z_i).next_z_i = None;
-    sort_linked(nodes, p_i);
-}
+    order.sort_unstable_by_key(|&(z, _)| z);
 
-/// Simon Tatham's linked list merge sort algorithm
-/// http://www.chiark.greenend.org.uk/~sgtatham/algorithms/listsort.html
-fn sort_linked(nodes: &mut [Node], list_i: NodeOffset) {
-    let mut in_size: u32 = 1;
-    let mut list_i = Some(list_i);
-
-    loop {
-        let mut p_i = list_i;
-        list_i = None;
-        let mut tail_i: Option<NodeOffset> = None;
-        let mut num_merges = 0;
-
-        while let Some(p_i_s) = p_i {
-            num_merges += 1;
-            let mut q_i = node!(nodes, p_i_s).next_z_i;
-            let mut p_size: u32 = 1;
-            for _ in 1..in_size {
-                if let Some(i) = q_i {
-                    p_size += 1;
-                    q_i = node!(nodes, i).next_z_i;
-                } else {
-                    break;
-                }
-            }
-            let mut q_size = in_size;
-
-            loop {
-                let e_i = if p_size > 0 {
-                    let Some(p_i_s) = p_i else { break };
-                    if q_size > 0 {
-                        if let Some(q_i_s) = q_i {
-                            if node!(nodes, p_i_s).z <= node!(nodes, q_i_s).z {
-                                p_size -= 1;
-                                let e = node_mut!(nodes, p_i_s);
-                                e.prev_z_i = tail_i;
-                                p_i = e.next_z_i;
-                                p_i_s
-                            } else {
-                                q_size -= 1;
-                                let e = node_mut!(nodes, q_i_s);
-                                e.prev_z_i = tail_i;
-                                q_i = e.next_z_i;
-                                q_i_s
-                            }
-                        } else {
-                            p_size -= 1;
-                            let e = node_mut!(nodes, p_i_s);
-                            e.prev_z_i = tail_i;
-                            p_i = e.next_z_i;
-                            p_i_s
-                        }
-                    } else {
-                        p_size -= 1;
-                        let e = node_mut!(nodes, p_i_s);
-                        e.prev_z_i = tail_i;
-                        p_i = e.next_z_i;
-                        p_i_s
-                    }
-                } else if q_size > 0 {
-                    if let Some(q_i_s) = q_i {
-                        q_size -= 1;
-                        let e = node_mut!(nodes, q_i_s);
-                        e.prev_z_i = tail_i;
-                        q_i = e.next_z_i;
-                        q_i_s
-                    } else {
-                        break;
-                    }
-                } else {
-                    break;
-                };
-
-                if let Some(tail_i) = tail_i {
-                    node_mut!(nodes, tail_i).next_z_i = Some(e_i);
-                } else {
-                    list_i = Some(e_i);
-                }
-                tail_i = Some(e_i);
-            }
-
-            p_i = q_i;
-        }
-
-        node_mut!(nodes, tail_i.unwrap()).next_z_i = None;
-        if num_merges <= 1 {
-            break;
-        }
-        in_size *= 2;
+    for idx in 0..order.len() {
+        let prev_z_i = if idx > 0 {
+            Some(order[idx - 1].1)
+        } else {
+            None
+        };
+        let next_z_i = order.get(idx + 1).map(|&(_, i)| i);
+        let p = node_mut!(nodes, order[idx].1);
+        p.prev_z_i = prev_z_i;
+        p.next_z_i = next_z_i;
     }
 }
 
@@ -755,12 +692,24 @@ fn intersects(p1: &Node, q1: &Node, p2: &Node, q2: &Node) -> bool {
 fn intersects_polygon(nodes: &[Node], a: &Node, b: &Node) -> bool {
     let ai = a.index();
     let bi = b.index();
+    let x0 = a.xy[0].min(b.xy[0]);
+    let y0 = a.xy[1].min(b.xy[1]);
+    let x1 = a.xy[0].max(b.xy[0]);
+    let y1 = a.xy[1].max(b.xy[1]);
     let mut p = a;
     loop {
         let p_next = node!(nodes, p.next_i);
         let pi = p.index();
         let pni = p_next.index();
+        let px0 = p.xy[0].min(p_next.xy[0]);
+        let py0 = p.xy[1].min(p_next.xy[1]);
+        let px1 = p.xy[0].max(p_next.xy[0]);
+        let py1 = p.xy[1].max(p_next.xy[1]);
         if (((pi != ai) && (pi != bi)) && ((pni != ai) && (pni != bi)))
+            && px0 <= x1
+            && px1 >= x0
+            && py0 <= y1
+            && py1 >= y0
             && intersects(p, p_next, a, b)
         {
             return true;
@@ -901,28 +850,15 @@ fn find_hole_bridge(nodes: &[Node], hole: &Node, outer_node_i: NodeOffset) -> Op
 
     let qx_t = qx as i32;
 
+    let (tri_a, tri_c) = if hole.xy[1] < mxmy[1] {
+        ([hole.xy[0], hole.xy[1]], [qx_t, hole.xy[1]])
+    } else {
+        ([qx_t, hole.xy[1]], [hole.xy[0], hole.xy[1]])
+    };
+
     loop {
         if (((hole.xy[0] >= p.xy[0]) & (p.xy[0] >= mxmy[0])) && hole.xy[0] != p.xy[0])
-            && point_in_triangle(
-                [
-                    if hole.xy[1] < mxmy[1] {
-                        hole.xy[0]
-                    } else {
-                        qx_t
-                    },
-                    hole.xy[1],
-                ],
-                mxmy,
-                [
-                    if hole.xy[1] < mxmy[1] {
-                        qx_t
-                    } else {
-                        hole.xy[0]
-                    },
-                    hole.xy[1],
-                ],
-                p.xy,
-            )
+            && point_in_triangle(tri_a, mxmy, tri_c, p.xy)
         {
             // tan = |hole.y - p.y| / (hole.x - p.x),  denom > 0 here.
             // Compare via cross-product so we never have to divide:
@@ -1060,10 +996,12 @@ fn remove_node(nodes: &mut [Node], pl: LinkInfo) -> (NodeOffset, NodeOffset) {
 }
 
 #[inline]
-fn input_bbox(data: &[[i32; 2]], start: usize, end: usize) -> InputBbox {
-    assert!(start < end && end <= data.len());
-    let mut bbox = InputBbox::new(data[start]);
-    for &xy in &data[start..end] {
+fn input_bbox(data: &[[i32; 2]]) -> InputBbox {
+    let Some((&first, rest)) = data.split_first() else {
+        panic!("input bbox requires a non-empty ring");
+    };
+    let mut bbox = InputBbox::new(first);
+    for &xy in rest {
         bbox.update(xy);
     }
     bbox
@@ -1073,17 +1011,22 @@ fn input_bbox(data: &[[i32; 2]], start: usize, end: usize) -> InputBbox {
 /// coordinates into the 15-bit z-order range.
 fn z_order(xy: [i32; 2], min_x: i32, min_y: i32, shift: u32) -> i32 {
     // coords are transformed into non-negative 15-bit integer range
-    let x = (((xy[0] as i64) - (min_x as i64)) >> shift) as u32 & 0x7FFF;
-    let y = (((xy[1] as i64) - (min_y as i64)) >> shift) as u32 & 0x7FFF;
-    let mut xy = (x as i64) << 32 | y as i64;
-    xy = (xy | (xy << 8)) & 0x00FF00FF00FF00FF;
-    xy = (xy | (xy << 4)) & 0x0F0F0F0F0F0F0F0F;
-    xy = (xy | (xy << 2)) & 0x3333333333333333;
-    xy = (xy | (xy << 1)) & 0x5555555555555555;
-    (xy >> 32 | xy << 1) as i32
+    let mut x = (((xy[0] as i64) - (min_x as i64)) >> shift) as u32 & 0x7FFF;
+    let mut y = (((xy[1] as i64) - (min_y as i64)) >> shift) as u32 & 0x7FFF;
+
+    x = (x | (x << 8)) & 0x00FF00FF;
+    x = (x | (x << 4)) & 0x0F0F0F0F;
+    x = (x | (x << 2)) & 0x33333333;
+    x = (x | (x << 1)) & 0x55555555;
+
+    y = (y | (y << 8)) & 0x00FF00FF;
+    y = (y | (y << 4)) & 0x0F0F0F0F;
+    y = (y | (y << 2)) & 0x33333333;
+    y = (y | (y << 1)) & 0x55555555;
+
+    (x | (y << 1)) as i32
 }
 
-#[allow(clippy::too_many_arguments)]
 fn point_in_triangle(a: [i32; 2], b: [i32; 2], c: [i32; 2], p: [i32; 2]) -> bool {
     let (ax, ay) = (a[0] as i64, a[1] as i64);
     let (bx, by) = (b[0] as i64, b[1] as i64);
@@ -1094,7 +1037,6 @@ fn point_in_triangle(a: [i32; 2], b: [i32; 2], c: [i32; 2], p: [i32; 2]) -> bool
         && ((bx - px) * (cy - py) >= (cx - px) * (by - py))
 }
 
-#[allow(clippy::too_many_arguments)]
 fn point_in_triangle_except_first(a: [i32; 2], b: [i32; 2], c: [i32; 2], p: [i32; 2]) -> bool {
     !(a[0] == p[0] && a[1] == p[1]) && point_in_triangle(a, b, c, p)
 }
@@ -1123,6 +1065,7 @@ pub struct EarcutI32 {
     data: Vec<[i32; 2]>,
     nodes: Vec<Node>,
     queue: Vec<(NodeOffset, i32)>,
+    sort_queue: Vec<(i32, NodeOffset)>,
 }
 
 impl Default for EarcutI32 {
@@ -1138,6 +1081,7 @@ impl EarcutI32 {
             data: Vec::new(),
             nodes: Vec::new(),
             queue: Vec::new(),
+            sort_queue: Vec::new(),
         }
     }
 
@@ -1157,14 +1101,16 @@ impl EarcutI32 {
         self.data.clear();
         self.data.extend(data);
         triangles_out.clear();
-        if self.data.len() < 3 {
-            return;
-        }
         self.earcut_impl(hole_indices, triangles_out);
     }
 
     fn earcut_impl<N: Index>(&mut self, hole_indices: &[N], triangles_out: &mut Vec<N>) {
-        triangles_out.reserve(self.data.len() + 1);
+        if self.data.len() < 3 {
+            return;
+        }
+        assert!(self.data.len() <= INDEX_MASK as usize + 1);
+
+        triangles_out.reserve(self.data.len() * 3);
         self.reset(self.data.len() / 2 * 3);
 
         let has_holes = !hole_indices.is_empty();
@@ -1180,7 +1126,7 @@ impl EarcutI32 {
         let mut small_path = false;
         let need_bbox = self.data.len() > 80 || !has_holes;
         if need_bbox {
-            let bbox = input_bbox(&self.data, 0, outer_len);
+            let bbox = input_bbox(&self.data[..outer_len]);
             min_x = bbox.min_x;
             min_y = bbox.min_y;
             let range_x = (bbox.max_x as i64) - (bbox.min_x as i64);
@@ -1213,15 +1159,20 @@ impl EarcutI32 {
             min_y,
             shift,
             small_path,
+            &mut self.sort_queue,
             Pass::P0,
         );
     }
 
     fn linked_list(&mut self, start: usize, end: usize, clockwise: bool) -> Option<NodeOffset> {
-        assert!(start <= end && end <= self.data.len());
+        let data = &self.data[start..end];
+        if data.is_empty() {
+            return None;
+        }
+
         let mut last_i = None;
-        let iter = self.data[start..end].iter().enumerate();
-        if clockwise == (signed_area(&self.data, start, end) > 0) {
+        let iter = data.iter().enumerate();
+        if clockwise == (signed_area(data) > 0) {
             for (i, &xy) in iter {
                 last_i = Some(insert_node(&mut self.nodes, (start + i) as u32, xy, last_i));
             }

--- a/src/int.rs
+++ b/src/int.rs
@@ -449,6 +449,9 @@ fn is_ear_hashed<'a>(
     let max_z = z_order(xy_max, min_x, min_y, shift);
 
     // look for points inside the triangle in increasing z-order
+    //
+    // Unlike the float version, we keep the bbox prefilter: the i32 comparisons are
+    // cheaper than i64 multiplications.
     let mut o_n = ear.next_z_i.map(|i| node!(nodes, i));
     while let Some(n) = o_n {
         if n.z > max_z {
@@ -997,11 +1000,8 @@ fn remove_node(nodes: &mut [Node], pl: LinkInfo) -> (NodeOffset, NodeOffset) {
 
 #[inline]
 fn input_bbox(data: &[[i32; 2]]) -> InputBbox {
-    let Some((&first, rest)) = data.split_first() else {
-        panic!("input bbox requires a non-empty ring");
-    };
-    let mut bbox = InputBbox::new(first);
-    for &xy in rest {
+    let mut bbox = InputBbox::new(data[0]);
+    for &xy in &data[1..] {
         bbox.update(xy);
     }
     bbox
@@ -1120,6 +1120,17 @@ impl EarcutI32 {
             self.data.len()
         };
 
+        let Some(mut outer_node_i) = self.linked_list(0, outer_len, true) else {
+            return;
+        };
+        let outer_node = node!(self.nodes, outer_node_i);
+        if outer_node.next_i == outer_node.prev_i {
+            return;
+        }
+        if has_holes {
+            outer_node_i = self.eliminate_holes(hole_indices, outer_node_i);
+        }
+
         let mut min_x = 0i32;
         let mut min_y = 0i32;
         let mut shift = NO_HASH;
@@ -1138,17 +1149,6 @@ impl EarcutI32 {
             if !has_holes && shift == NO_HASH {
                 small_path = use_small_path(range_x, range_y);
             }
-        }
-
-        let Some(mut outer_node_i) = self.linked_list(0, outer_len, true) else {
-            return;
-        };
-        let outer_node = node!(self.nodes, outer_node_i);
-        if outer_node.next_i == outer_node.prev_i {
-            return;
-        }
-        if has_holes {
-            outer_node_i = self.eliminate_holes(hole_indices, outer_node_i);
         }
 
         earcut_linked(

--- a/src/int.rs
+++ b/src/int.rs
@@ -86,7 +86,7 @@ pub fn deviation<N: Index>(
         true => hole_indices[0].into_usize(),
         false => data.len(),
     };
-    let polygon_area = if data.len() < 3 {
+    let polygon_area = if data.len() < 3 || outer_len < 3 {
         0
     } else {
         let mut polygon_area = signed_area(&data[..outer_len]).abs();

--- a/src/int.rs
+++ b/src/int.rs
@@ -1110,7 +1110,7 @@ impl EarcutI32 {
         }
         assert!(self.data.len() <= INDEX_MASK as usize + 1);
 
-        triangles_out.reserve(self.data.len() * 3);
+        triangles_out.reserve(self.data.len().saturating_mul(3));
         self.reset(self.data.len() / 2 * 3);
 
         let has_holes = !hole_indices.is_empty();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1109,7 +1109,7 @@ pub fn deviation<T: Float, N: Index>(
         true => hole_indices[0].into_usize(),
         false => data.len(),
     };
-    let polygon_area = if data.len() < 3 {
+    let polygon_area = if data.len() < 3 || outer_len < 3 {
         T::zero()
     } else {
         let mut polygon_area = signed_area(&data[..outer_len]).abs();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,7 +249,7 @@ impl<T: Float> Earcut<T> {
         }
         assert!(self.data.len() <= INDEX_MASK as usize + 1);
 
-        triangles_out.reserve(self.data.len() * 3);
+        triangles_out.reserve(self.data.len().saturating_mul(3));
         self.reset(self.data.len() / 2 * 3);
 
         let has_holes = !hole_indices.is_empty();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,12 +24,12 @@ macro_rules! node {
 macro_rules! node_mut {
     ($self:ident.$nodes:ident, $offset:expr) => {
         // SAFETY: all `NodeOffset`s used by this crate follow the invariant
-        // documented on `node_at_mut`.
+        // documented on `node_at`.
         unsafe { $crate::node_at_mut(&mut $self.$nodes, $offset) }
     };
     ($nodes:ident, $offset:expr) => {
         // SAFETY: all `NodeOffset`s used by this crate follow the invariant
-        // documented on `node_at_mut`.
+        // documented on `node_at`.
         unsafe { $crate::node_at_mut($nodes, $offset) }
     };
 }
@@ -133,7 +133,7 @@ struct Node<T: Float> {
     i_steiner: u32,
     /// z-order curve value
     z: i32,
-    /// vertex coordinates x
+    /// vertex coordinates
     xy: [T; 2],
     /// previous vertex nodes in a polygon ring
     prev_i: NodeOffset,
@@ -199,6 +199,7 @@ pub struct Earcut<T: Float> {
     data: Vec<[T; 2]>,
     nodes: Vec<Node<T>>,
     queue: Vec<(NodeOffset, T)>,
+    sort_queue: Vec<(i32, NodeOffset)>,
 }
 
 impl<T: Float> Default for Earcut<T> {
@@ -216,6 +217,7 @@ impl<T: Float> Earcut<T> {
             data: Vec::new(),
             nodes: Vec::new(),
             queue: Vec::new(),
+            sort_queue: Vec::new(),
         }
     }
 
@@ -238,14 +240,16 @@ impl<T: Float> Earcut<T> {
         self.data.clear();
         self.data.extend(data);
         triangles_out.clear();
-        if self.data.len() < 3 {
-            return;
-        }
         self.earcut_impl(hole_indices, triangles_out);
     }
 
     pub fn earcut_impl<N: Index>(&mut self, hole_indices: &[N], triangles_out: &mut Vec<N>) {
-        triangles_out.reserve(self.data.len() + 1);
+        if self.data.len() < 3 {
+            return;
+        }
+        assert!(self.data.len() <= INDEX_MASK as usize + 1);
+
+        triangles_out.reserve(self.data.len() * 3);
         self.reset(self.data.len() / 2 * 3);
 
         let has_holes = !hole_indices.is_empty();
@@ -297,17 +301,22 @@ impl<T: Float> Earcut<T> {
             min_x,
             min_y,
             inv_size,
+            &mut self.sort_queue,
             Pass::P0,
         );
     }
 
     /// create a circular doubly linked list from polygon points in the specified winding order
     fn linked_list(&mut self, start: usize, end: usize, clockwise: bool) -> Option<NodeOffset> {
-        assert!(start <= end && end <= self.data.len());
-        let mut last_i: Option<NodeOffset> = None;
-        let iter = self.data[start..end].iter().enumerate();
+        let data = &self.data[start..end];
+        if data.is_empty() {
+            return None;
+        }
 
-        if clockwise == (signed_area(&self.data, start, end) > T::zero()) {
+        let mut last_i: Option<NodeOffset> = None;
+        let iter = data.iter().enumerate();
+
+        if clockwise == (signed_area(data) > T::zero()) {
             for (i, &xy) in iter {
                 let idx = start + i;
                 last_i = Some(insert_node(&mut self.nodes, idx as u32, xy, last_i));
@@ -371,10 +380,10 @@ impl<T: Float> Earcut<T> {
                 Some(ordering) => return ordering,
                 None => return Ordering::Equal,
             };
-            let a_slope = (node!(self.nodes, a.next_i).xy[1] - a.xy[1])
-                / (node!(self.nodes, a.next_i).xy[0] - a.xy[0]);
-            let b_slope = (node!(self.nodes, b.next_i).xy[1] - b.xy[1])
-                / (node!(self.nodes, b.next_i).xy[0] - b.xy[0]);
+            let a_next = node!(self.nodes, a.next_i);
+            let b_next = node!(self.nodes, b.next_i);
+            let a_slope = (a_next.xy[1] - a.xy[1]) / (a_next.xy[0] - a.xy[0]);
+            let b_slope = (b_next.xy[1] - b.xy[1]) / (b_next.xy[0] - b.xy[0]);
             a_slope.partial_cmp(&b_slope).unwrap_or(Ordering::Equal)
         });
 
@@ -403,13 +412,14 @@ fn earcut_linked<T: Float, N: Index>(
     min_x: T,
     min_y: T,
     inv_size: T,
+    sort_queue: &mut Vec<(i32, NodeOffset)>,
     pass: Pass,
 ) {
     let mut ear_i = ear_i;
 
     // interlink polygon nodes in z-order
     if pass == Pass::P0 && inv_size != T::zero() {
-        index_curve(nodes, ear_i, min_x, min_y, inv_size);
+        index_curve(nodes, ear_i, min_x, min_y, inv_size, sort_queue);
     }
 
     let mut stop_i = ear_i;
@@ -454,15 +464,33 @@ fn earcut_linked<T: Float, N: Index>(
             if pass == Pass::P0 {
                 // try filtering points and slicing again
                 ear_i = filter_points(nodes, ear_i, None);
-                earcut_linked(nodes, ear_i, triangles, min_x, min_y, inv_size, Pass::P1);
+                earcut_linked(
+                    nodes,
+                    ear_i,
+                    triangles,
+                    min_x,
+                    min_y,
+                    inv_size,
+                    sort_queue,
+                    Pass::P1,
+                );
             } else if pass == Pass::P1 {
                 // if this didn't work, try curing all small self-intersections locally
                 let filtered = filter_points(nodes, ear_i, None);
                 ear_i = cure_local_intersections(nodes, filtered, triangles);
-                earcut_linked(nodes, ear_i, triangles, min_x, min_y, inv_size, Pass::P2);
-            } else if pass == Pass::P2 {
+                earcut_linked(
+                    nodes,
+                    ear_i,
+                    triangles,
+                    min_x,
+                    min_y,
+                    inv_size,
+                    sort_queue,
+                    Pass::P2,
+                );
+            } else {
                 // as a last resort, try splitting the remaining polygon into two
-                split_earcut(nodes, ear_i, triangles, min_x, min_y, inv_size);
+                split_earcut(nodes, ear_i, triangles, min_x, min_y, inv_size, sort_queue);
             }
             return;
         }
@@ -485,7 +513,7 @@ fn is_ear<'a, T: Float>(
 
     // now make sure we don't have other points inside the potential ear
 
-    // triangle bbox
+    // triangle bbox for z-order range
     let x0 = a.xy[0].min(b.xy[0].min(c.xy[0]));
     let y0 = a.xy[1].min(b.xy[1].min(c.xy[1]));
     let x1 = a.xy[0].max(b.xy[0].max(c.xy[0]));
@@ -522,14 +550,20 @@ fn is_ear_hashed<'a, T: Float>(
         return (false, a, c);
     }
 
+    // Cache vertex coordinates in stack locals so the inner loops don't
+    // reload them through the (potentially aliased) node references.
+    let a_xy = a.xy;
+    let b_xy = b.xy;
+    let c_xy = c.xy;
+
     // triangle bbox
     let xy_min = [
-        a.xy[0].min(b.xy[0].min(c.xy[0])),
-        a.xy[1].min(b.xy[1].min(c.xy[1])),
+        a_xy[0].min(b_xy[0].min(c_xy[0])),
+        a_xy[1].min(b_xy[1].min(c_xy[1])),
     ];
     let xy_max = [
-        a.xy[0].max(b.xy[0].max(c.xy[0])),
-        a.xy[1].max(b.xy[1].max(c.xy[1])),
+        a_xy[0].max(b_xy[0].max(c_xy[0])),
+        a_xy[1].max(b_xy[1].max(c_xy[1])),
     ];
 
     // z-order range for the current triangle bbox;
@@ -542,12 +576,8 @@ fn is_ear_hashed<'a, T: Float>(
         if n.z > max_z {
             break;
         };
-        if ((n.xy[0] >= xy_min[0])
-            & (n.xy[0] <= xy_max[0])
-            & (n.xy[1] >= xy_min[1])
-            & (n.xy[1] <= xy_max[1]))
-            && (!ptr::eq(n, a) && !ptr::eq(n, c))
-            && point_in_triangle_except_first(a.xy, b.xy, c.xy, n.xy)
+        if (!ptr::eq(n, a) && !ptr::eq(n, c))
+            && point_in_triangle_except_first(a_xy, b_xy, c_xy, n.xy)
             && area(node!(nodes, n.prev_i), n, node!(nodes, n.next_i)) >= T::zero()
         {
             return (false, a, c);
@@ -561,12 +591,8 @@ fn is_ear_hashed<'a, T: Float>(
         if p.z < min_z {
             break;
         };
-        if ((p.xy[0] >= xy_min[0])
-            & (p.xy[0] <= xy_max[0])
-            & (p.xy[1] >= xy_min[1])
-            & (p.xy[1] <= xy_max[1]))
-            && (!ptr::eq(p, a) && !ptr::eq(p, c))
-            && point_in_triangle_except_first(a.xy, b.xy, c.xy, p.xy)
+        if (!ptr::eq(p, a) && !ptr::eq(p, c))
+            && point_in_triangle_except_first(a_xy, b_xy, c_xy, p.xy)
             && area(node!(nodes, p.prev_i), p, node!(nodes, p.next_i)) >= T::zero()
         {
             return (false, a, c);
@@ -627,6 +653,7 @@ fn split_earcut<T: Float, N: Index>(
     min_x: T,
     min_y: T,
     inv_size: T,
+    sort_queue: &mut Vec<(i32, NodeOffset)>,
 ) {
     // look for a valid diagonal that divides the polygon into two
     let mut ai = start_i;
@@ -649,8 +676,26 @@ fn split_earcut<T: Float, N: Index>(
                 ci = filter_points(nodes, ci, end_i);
 
                 // run earcut on each half
-                earcut_linked(nodes, ai, triangles, min_x, min_y, inv_size, Pass::P0);
-                earcut_linked(nodes, ci, triangles, min_x, min_y, inv_size, Pass::P0);
+                earcut_linked(
+                    nodes,
+                    ai,
+                    triangles,
+                    min_x,
+                    min_y,
+                    inv_size,
+                    sort_queue,
+                    Pass::P0,
+                );
+                earcut_linked(
+                    nodes,
+                    ci,
+                    triangles,
+                    min_x,
+                    min_y,
+                    inv_size,
+                    sort_queue,
+                    Pass::P0,
+                );
                 return;
             }
             bi = b.next_i;
@@ -671,7 +716,9 @@ fn index_curve<T: Float>(
     min_x: T,
     min_y: T,
     inv_size: T,
+    order: &mut Vec<(i32, NodeOffset)>,
 ) {
+    order.clear();
     let mut p_i = start_i;
     let mut p = node_mut!(nodes, p_i);
 
@@ -679,8 +726,7 @@ fn index_curve<T: Float>(
         if p.z == 0 {
             p.z = z_order(p.xy, min_x, min_y, inv_size);
         }
-        p.prev_z_i = Some(p.prev_i);
-        p.next_z_i = Some(p.next_i);
+        order.push((p.z, p_i));
         p_i = p.next_i;
         p = node_mut!(nodes, p_i);
         if p_i == start_i {
@@ -688,99 +734,18 @@ fn index_curve<T: Float>(
         }
     }
 
-    let p_prev_z_i = p.prev_z_i.take().unwrap();
-    node_mut!(nodes, p_prev_z_i).next_z_i = None;
-    sort_linked(nodes, p_i);
-}
+    order.sort_unstable_by_key(|&(z, _)| z);
 
-/// Simon Tatham's linked list merge sort algorithm
-/// http://www.chiark.greenend.org.uk/~sgtatham/algorithms/listsort.html
-fn sort_linked<T: Float>(nodes: &mut [Node<T>], list_i: NodeOffset) {
-    let mut in_size: u32 = 1;
-    let mut list_i = Some(list_i);
-
-    loop {
-        let mut p_i = list_i;
-        list_i = None;
-        let mut tail_i: Option<NodeOffset> = None;
-        let mut num_merges = 0;
-
-        while let Some(p_i_s) = p_i {
-            num_merges += 1;
-            let mut q_i = node!(nodes, p_i_s).next_z_i;
-            let mut p_size: u32 = 1;
-            for _ in 1..in_size {
-                if let Some(i) = q_i {
-                    p_size += 1;
-                    q_i = node!(nodes, i).next_z_i;
-                } else {
-                    break;
-                }
-            }
-            let mut q_size = in_size;
-
-            loop {
-                let e_i = if p_size > 0 {
-                    let Some(p_i_s) = p_i else { break };
-                    if q_size > 0 {
-                        if let Some(q_i_s) = q_i {
-                            if node!(nodes, p_i_s).z <= node!(nodes, q_i_s).z {
-                                p_size -= 1;
-                                let e = node_mut!(nodes, p_i_s);
-                                e.prev_z_i = tail_i;
-                                p_i = e.next_z_i;
-                                p_i_s
-                            } else {
-                                q_size -= 1;
-                                let e = node_mut!(nodes, q_i_s);
-                                e.prev_z_i = tail_i;
-                                q_i = e.next_z_i;
-                                q_i_s
-                            }
-                        } else {
-                            p_size -= 1;
-                            let e = node_mut!(nodes, p_i_s);
-                            e.prev_z_i = tail_i;
-                            p_i = e.next_z_i;
-                            p_i_s
-                        }
-                    } else {
-                        p_size -= 1;
-                        let e = node_mut!(nodes, p_i_s);
-                        e.prev_z_i = tail_i;
-                        p_i = e.next_z_i;
-                        p_i_s
-                    }
-                } else if q_size > 0 {
-                    if let Some(q_i_s) = q_i {
-                        q_size -= 1;
-                        let e = node_mut!(nodes, q_i_s);
-                        e.prev_z_i = tail_i;
-                        q_i = e.next_z_i;
-                        q_i_s
-                    } else {
-                        break;
-                    }
-                } else {
-                    break;
-                };
-
-                if let Some(tail_i) = tail_i {
-                    node_mut!(nodes, tail_i).next_z_i = Some(e_i);
-                } else {
-                    list_i = Some(e_i);
-                }
-                tail_i = Some(e_i);
-            }
-
-            p_i = q_i;
-        }
-
-        node_mut!(nodes, tail_i.unwrap()).next_z_i = None;
-        if num_merges <= 1 {
-            break;
-        }
-        in_size *= 2;
+    for idx in 0..order.len() {
+        let prev_z_i = if idx > 0 {
+            Some(order[idx - 1].1)
+        } else {
+            None
+        };
+        let next_z_i = order.get(idx + 1).map(|&(_, i)| i);
+        let p = node_mut!(nodes, order[idx].1);
+        p.prev_z_i = prev_z_i;
+        p.next_z_i = next_z_i;
     }
 }
 
@@ -811,18 +776,22 @@ fn is_valid_diagonal<T: Float>(
     a_next: &Node<T>,
     a_prev: &Node<T>,
 ) -> bool {
+    if a_next.index() == b.index() || a_prev.index() == b.index() {
+        return false;
+    }
+
     let b_next = node!(nodes, b.next_i);
     let b_prev = node!(nodes, b.prev_i);
-    // dones't intersect other edges
-    (((a_next.index() != b.index()) && (a_prev.index() != b.index())) && !intersects_polygon(nodes, a, b))
-        // locally visible
-        && ((locally_inside(nodes, a, b) && locally_inside(nodes, b, a) && middle_inside(nodes, a, b))
-            // does not create opposite-facing sectors
-            && (area(a_prev, a, b_prev) != T::zero() || area(a, b_prev, b) != T::zero())
-            // special zero-length case
-            || equals(a, b)
-                && area(a_prev, a, a_next) > T::zero()
-                && area(b_prev, b, b_next) > T::zero())
+
+    let locally_visible = locally_inside(nodes, a, b)
+        && locally_inside(nodes, b, a)
+        && middle_inside(nodes, a, b)
+        // does not create opposite-facing sectors
+        && (area(a_prev, a, b_prev) != T::zero() || area(a, b_prev, b) != T::zero());
+    let zero_length_valid =
+        equals(a, b) && area(a_prev, a, a_next) > T::zero() && area(b_prev, b, b_next) > T::zero();
+
+    (locally_visible || zero_length_valid) && !intersects_polygon(nodes, a, b)
 }
 
 /// check if two segments intersect
@@ -842,12 +811,24 @@ fn intersects<T: Float>(p1: &Node<T>, q1: &Node<T>, p2: &Node<T>, q2: &Node<T>) 
 fn intersects_polygon<T: Float>(nodes: &[Node<T>], a: &Node<T>, b: &Node<T>) -> bool {
     let ai = a.index();
     let bi = b.index();
+    let x0 = a.xy[0].min(b.xy[0]);
+    let y0 = a.xy[1].min(b.xy[1]);
+    let x1 = a.xy[0].max(b.xy[0]);
+    let y1 = a.xy[1].max(b.xy[1]);
     let mut p = a;
     loop {
         let p_next = node!(nodes, p.next_i);
         let pi = p.index();
         let pni = p_next.index();
+        let px0 = p.xy[0].min(p_next.xy[0]);
+        let py0 = p.xy[1].min(p_next.xy[1]);
+        let px1 = p.xy[0].max(p_next.xy[0]);
+        let py1 = p.xy[1].max(p_next.xy[1]);
         if (((pi != ai) && (pi != bi)) && ((pni != ai) && (pni != bi)))
+            && px0 <= x1
+            && px1 >= x0
+            && py0 <= y1
+            && py1 >= y0
             && intersects(p, p_next, a, b)
         {
             return true;
@@ -966,20 +947,15 @@ fn find_hole_bridge<T: Float>(
     p_i = m_i;
     let mut p = m;
 
+    let (tri_a, tri_c) = if hole.xy[1] < mxmy[1] {
+        ([hole.xy[0], hole.xy[1]], [qx, hole.xy[1]])
+    } else {
+        ([qx, hole.xy[1]], [hole.xy[0], hole.xy[1]])
+    };
+
     loop {
         if (((hole.xy[0] >= p.xy[0]) & (p.xy[0] >= mxmy[0])) && hole.xy[0] != p.xy[0])
-            && point_in_triangle(
-                [
-                    if hole.xy[1] < mxmy[1] { hole.xy[0] } else { qx },
-                    hole.xy[1],
-                ],
-                mxmy,
-                [
-                    if hole.xy[1] < mxmy[1] { qx } else { hole.xy[0] },
-                    hole.xy[1],
-                ],
-                p.xy,
-            )
+            && point_in_triangle(tri_a, mxmy, tri_c, p.xy)
         {
             let tan = (hole.xy[1] - p.xy[1]).abs() / (hole.xy[0] - p.xy[0]);
             if locally_inside(nodes, p, hole)
@@ -1136,7 +1112,7 @@ pub fn deviation<T: Float, N: Index>(
     let polygon_area = if data.len() < 3 {
         T::zero()
     } else {
-        let mut polygon_area = signed_area(&data, 0, outer_len).abs();
+        let mut polygon_area = signed_area(&data[..outer_len]).abs();
         if has_holes {
             for i in 0..hole_indices.len() {
                 let start = hole_indices[i].into_usize();
@@ -1146,7 +1122,7 @@ pub fn deviation<T: Float, N: Index>(
                     data.len()
                 };
                 if end - start >= 3 {
-                    polygon_area = polygon_area - signed_area(&data, start, end).abs();
+                    polygon_area = polygon_area - signed_area(&data[start..end]).abs();
                 }
             }
         }
@@ -1173,12 +1149,12 @@ pub fn deviation<T: Float, N: Index>(
     }
 }
 
-/// check if a point lies within a convex triangle
-fn signed_area<T: Float>(data: &[[T; 2]], start: usize, end: usize) -> T {
-    assert!(end > 0 && start <= end && end <= data.len());
-    let [mut bx, mut by] = data[end - 1];
+/// signed area of a polygon ring (twice the geometric area)
+fn signed_area<T: Float>(data: &[[T; 2]]) -> T {
+    debug_assert!(!data.is_empty());
+    let [mut bx, mut by] = data[data.len() - 1];
     let mut sum = T::zero();
-    for &[ax, ay] in &data[start..end] {
+    for &[ax, ay] in data {
         sum = sum + (bx - ax) * (ay + by);
         (bx, by) = (ax, ay);
     }
@@ -1188,24 +1164,33 @@ fn signed_area<T: Float>(data: &[[T; 2]], start: usize, end: usize) -> T {
 /// z-order of a point given coords and inverse of the longer side of data bbox
 fn z_order<T: Float>(xy: [T; 2], min_x: T, min_y: T, inv_size: T) -> i32 {
     // coords are transformed into non-negative 15-bit integer range
-    let x = ((xy[0] - min_x) * inv_size).to_u32().unwrap();
-    let y = ((xy[1] - min_y) * inv_size).to_u32().unwrap();
-    let mut xy = (x as i64) << 32 | y as i64;
-    xy = (xy | (xy << 8)) & 0x00FF00FF00FF00FF;
-    xy = (xy | (xy << 4)) & 0x0F0F0F0F0F0F0F0F;
-    xy = (xy | (xy << 2)) & 0x3333333333333333;
-    xy = (xy | (xy << 1)) & 0x5555555555555555;
-    (xy >> 32 | xy << 1) as i32
+    let x_scaled = (xy[0] - min_x) * inv_size;
+    let y_scaled = (xy[1] - min_y) * inv_size;
+    debug_assert!(x_scaled >= T::zero() && x_scaled < T::from(32768.0).unwrap());
+    debug_assert!(y_scaled >= T::zero() && y_scaled < T::from(32768.0).unwrap());
+
+    let mut x = x_scaled.to_f64().unwrap() as u32;
+    let mut y = y_scaled.to_f64().unwrap() as u32;
+
+    x = (x | (x << 8)) & 0x00FF00FF;
+    x = (x | (x << 4)) & 0x0F0F0F0F;
+    x = (x | (x << 2)) & 0x33333333;
+    x = (x | (x << 1)) & 0x55555555;
+
+    y = (y | (y << 8)) & 0x00FF00FF;
+    y = (y | (y << 4)) & 0x0F0F0F0F;
+    y = (y | (y << 2)) & 0x33333333;
+    y = (y | (y << 1)) & 0x55555555;
+
+    (x | (y << 1)) as i32
 }
 
-#[allow(clippy::too_many_arguments)]
 fn point_in_triangle<T: Float>(a: [T; 2], b: [T; 2], c: [T; 2], p: [T; 2]) -> bool {
     ((c[0] - p[0]) * (a[1] - p[1]) >= (a[0] - p[0]) * (c[1] - p[1]))
         && ((a[0] - p[0]) * (b[1] - p[1]) >= (b[0] - p[0]) * (a[1] - p[1]))
         && ((b[0] - p[0]) * (c[1] - p[1]) >= (c[0] - p[0]) * (b[1] - p[1]))
 }
 
-#[allow(clippy::too_many_arguments)]
 fn point_in_triangle_except_first<T: Float>(a: [T; 2], b: [T; 2], c: [T; 2], p: [T; 2]) -> bool {
     !(a[0] == p[0] && a[1] == p[1]) && point_in_triangle(a, b, c, p)
 }

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -1,3 +1,4 @@
+use earcut::int::EarcutI32;
 use earcut::{Earcut, deviation};
 
 #[test]
@@ -158,6 +159,70 @@ fn test_map_3d_to_2d() {
         deviation(data.iter().map(|v| [v[0], v[1]]), hole_indices, &triangles),
         0.0
     );
+}
+
+#[test]
+fn test_int_empty() {
+    let mut earcut = EarcutI32::new();
+    let data: [[i32; 2]; 0] = [];
+    let hole_indices: &[u32] = &[];
+    let mut triangles: Vec<u32> = vec![];
+    earcut.earcut(data.iter().copied(), hole_indices, &mut triangles);
+    assert_eq!(triangles.len(), 0);
+}
+
+#[test]
+fn test_int_invalid_point() {
+    let mut earcut = EarcutI32::new();
+    let data = [[100, 200]];
+    let hole_indices: &[u32] = &[];
+    let mut triangles: Vec<u32> = vec![];
+    earcut.earcut(data.iter().copied(), hole_indices, &mut triangles);
+    assert_eq!(triangles.len(), 0);
+}
+
+#[test]
+fn test_int_invalid_line() {
+    let mut earcut = EarcutI32::new();
+    let data = [[0, 0], [100, 200]];
+    let hole_indices: &[u32] = &[];
+    let mut triangles: Vec<u32> = vec![];
+    earcut.earcut(data.iter().copied(), hole_indices, &mut triangles);
+    assert_eq!(triangles.len(), 0);
+}
+
+#[test]
+fn test_int_empty_outer_ring() {
+    // hole_indices[0] == 0 means the outer ring is empty: matches JS behavior
+    // by returning empty triangles instead of panicking.
+    let mut earcut = EarcutI32::new();
+    let data = [[0, 0], [100, 0], [100, 100], [0, 100]];
+    let hole_indices: &[u32] = &[0];
+    let mut triangles: Vec<u32> = vec![];
+    earcut.earcut(data.iter().copied(), hole_indices, &mut triangles);
+    assert_eq!(triangles.len(), 0);
+}
+
+#[test]
+fn test_int_degenerate_outer_ring() {
+    // outer ring with 2 vertices: linked list builds a degenerate ring where
+    // `prev_i == next_i`, exercising the degenerate-ring early return.
+    let mut earcut = EarcutI32::new();
+    let data = [[0, 0], [100, 0], [10, 10], [90, 10], [10, 90]];
+    let hole_indices: &[u32] = &[2];
+    let mut triangles: Vec<u32> = vec![];
+    earcut.earcut(data.iter().copied(), hole_indices, &mut triangles);
+    assert_eq!(triangles.len(), 0);
+}
+
+#[test]
+fn test_int_square() {
+    let mut earcut = EarcutI32::new();
+    let data = [[0, 0], [100, 0], [100, 100], [0, 100]];
+    let hole_indices: &[u32] = &[];
+    let mut triangles: Vec<u32> = vec![];
+    earcut.earcut(data.iter().copied(), hole_indices, &mut triangles);
+    assert_eq!(triangles, vec![2, 3, 0, 0, 1, 2]);
 }
 
 #[test]

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -1,4 +1,4 @@
-use earcut::int::EarcutI32;
+use earcut::int::{EarcutI32, deviation as int_deviation};
 use earcut::{Earcut, deviation};
 
 #[test]
@@ -194,13 +194,16 @@ fn test_int_invalid_line() {
 #[test]
 fn test_int_empty_outer_ring() {
     // hole_indices[0] == 0 means the outer ring is empty: matches JS behavior
-    // by returning empty triangles instead of panicking.
     let mut earcut = EarcutI32::new();
     let data = [[0, 0], [100, 0], [100, 100], [0, 100]];
     let hole_indices: &[u32] = &[0];
     let mut triangles: Vec<u32> = vec![];
     earcut.earcut(data.iter().copied(), hole_indices, &mut triangles);
     assert_eq!(triangles.len(), 0);
+    assert_eq!(
+        int_deviation(data.iter().copied(), hole_indices, &triangles),
+        0
+    );
 }
 
 #[test]
@@ -213,6 +216,10 @@ fn test_int_degenerate_outer_ring() {
     let mut triangles: Vec<u32> = vec![];
     earcut.earcut(data.iter().copied(), hole_indices, &mut triangles);
     assert_eq!(triangles.len(), 0);
+    assert_eq!(
+        int_deviation(data.iter().copied(), hole_indices, &triangles),
+        0
+    );
 }
 
 #[test]


### PR DESCRIPTION
| Polygon     |   before |    after |     Δ |
|-------------|---------:|---------:|------:|
| dude        | 4.535 µs | 4.204 µs | -7.3% |
| water       | 400.9 µs | 345.8 µs | -13.7% |
| water2      | 291.4 µs | 249.7 µs | -14.3% |
| water3      | 13.03 µs | 11.91 µs | -8.6% |
| water4      | 74.78 µs | 67.40 µs | -9.9% |
| water_huge  | 7.456 ms | 7.059 ms | -5.3% |
| water_huge2 | 16.26 ms | 14.82 ms | -8.9% |

---
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to the project's change log file if knowledge of this change could be valuable to users.
  - Usually called `CHANGES.md` or `CHANGELOG.md`
  - Prefix changelog entries for breaking changes with "BREAKING: "

