### PR TITLE
chore: restore earcut_impl as deprecated and document utils3d

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Rust port of the [mapbox/earcut](https://github.com/mapbox/earcut) polygon tri
 - Based on the latest earcut 3.0.2 release.
 - Designed to avoid unnecessary memory allocations. Internal buffers and the output index vector can be reused across multiple triangulations.
 - Also provides `earcut::int::EarcutI32` for integer coordinates with exact integer predicates, but it can be slower than the float-based `Earcut` on modern CPUs.
-- An additional module, `utils3d`, can project 3D coplanar polygons onto a 2D plane before triangulation.
+- An additional helper, `utils3d::project3d_to_2d`, projects coplanar 3D polygons onto a 2D plane for use with earcut.
 
 <p align="center">
 <img src="./docs/image.png" width="300">

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,6 +246,15 @@ impl<T: Float> Earcut<T> {
         self.data.clear();
         self.data.extend(data);
         triangles_out.clear();
+        self.run(hole_indices, triangles_out);
+    }
+
+    #[deprecated(since = "0.4.10", note = "internal entry point; call `earcut` instead")]
+    pub fn earcut_impl<N: Index>(&mut self, hole_indices: &[N], triangles_out: &mut Vec<N>) {
+        self.run(hole_indices, triangles_out);
+    }
+
+    fn run<N: Index>(&mut self, hole_indices: &[N], triangles_out: &mut Vec<N>) {
         if self.data.len() < 3 {
             return;
         }

--- a/src/utils3d.rs
+++ b/src/utils3d.rs
@@ -1,3 +1,5 @@
+//! Helpers for projecting 3D coplanar polygons onto a 2D plane
+
 use alloc::vec::Vec;
 use num_traits::float::Float;
 
@@ -32,6 +34,13 @@ fn normal<T: Float>(vertices: &[[T; 3]]) -> Option<[T; 3]> {
     Some([sum[0] / d, sum[1] / d, sum[2] / d])
 }
 
+/// Projects a coplanar 3D polygon onto a 2D plane.
+///
+/// The plane is derived from the normal of the outer ring
+/// (`vertices[0..num_outer]`).
+///
+/// Returns `false` if the outer ring has fewer than three vertices, or if
+/// its normal is degenerate (e.g. all points are collinear).
 pub fn project3d_to_2d<T: Float>(
     vertices: &[[T; 3]],
     num_outer: usize,


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to the project's change log file if knowledge of this change could be valuable to users.
  - Usually called `CHANGES.md` or `CHANGELOG.md`
  - Prefix changelog entries for breaking changes with "BREAKING: "